### PR TITLE
Polling interface on Submit trait.

### DIFF
--- a/src/submission.rs
+++ b/src/submission.rs
@@ -8,43 +8,80 @@ use std::task::{Context, Poll};
 use crate::{Event, Submit, Completion};
 
 pub struct Submission<E: Event, S> {
+    state: State,
     event: ManuallyDrop<E>,
-    completion: Option<NonNull<Completion>>,
-    submitter: Option<S>,
+    driver: ManuallyDrop<S>,
+    completion: NonNull<Completion>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum State {
+    Waiting,
+    Prepared,
+    Submitted,
+    Complete,
 }
 
 impl<E: Event, S: Submit> Submission<E, S> {
-    pub fn new(mut event: E, mut submitter: S) -> Submission<E, S> {
-        unsafe {
-            let completion = Box::new(Completion::new());
+    pub fn new(event: E, driver: S) -> Submission<E, S> {
+        Submission {
+            state: State::Waiting,
+            event: ManuallyDrop::new(event),
+            driver: ManuallyDrop::new(driver),
+            completion: NonNull::dangling(),
+        }
+    }
 
-            submitter.prepare(|sqe| {
-                // Use the SubmissionCleaner guard to clear the submission of any data
-                // in case the Event::prepare method panics
-                struct SubmissionCleaner<'a>(iou::SubmissionQueueEvent<'a>);
-
-                impl<'a> Drop for SubmissionCleaner<'a> {
-                    fn drop(&mut self) {
-                        unsafe {
-                            self.0.prep_nop();
-                            self.0.set_user_data(0);
-                        }
-                    }
-                }
-
-                let mut sqe = SubmissionCleaner(sqe);
-                event.prepare(&mut sqe.0);
-                sqe.0.set_user_data(&*completion as *const Completion as usize as u64);
-                mem::forget(sqe);
-            });
-
-            let completion = NonNull::new_unchecked(Box::into_raw(completion));
-
-            Submission {
-                event: ManuallyDrop::new(event),
-                completion: Some(completion),
-                submitter: Some(submitter),
+    #[inline(always)]
+    unsafe fn try_prepare(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<()> {
+        let (event, driver) = self.as_mut().event_and_driver();
+        match driver.poll_prepare(ctx, |sqe, ctx| prepare(sqe, ctx, event)) {
+            Poll::Ready(completion) => {
+                let this = Pin::get_unchecked_mut(self);
+                this.state = State::Prepared;
+                this.completion = completion;
+                Poll::Ready(())
             }
+            Poll::Pending           => Poll::Pending,
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn try_submit(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) {
+        match self.as_mut().driver().poll_submit(ctx) {
+            Poll::Ready(result)  => {
+                let _ = result; // TODO figure out how to handle this result
+                Pin::get_unchecked_mut(self).state = State::Submitted;
+            }
+            Poll::Pending       => { }
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn try_complete(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<(E, io::Result<usize>)> {
+        let this = Pin::get_unchecked_mut(self);
+        if let Some(result) = this.completion.as_ref().check() {
+            this.state = State::Complete;
+            drop(Box::<Completion>::from_raw(this.completion.as_ptr()));
+            ManuallyDrop::drop(&mut this.driver);
+            let event = ManuallyDrop::take(&mut this.event);
+            Poll::Ready((event, result))
+        } else {
+            this.completion.as_mut().set_waker(ctx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    #[inline(always)]
+    fn driver(self: Pin<&mut Self>) -> Pin<&mut S> {
+        unsafe { Pin::map_unchecked_mut(self, |this| &mut *this.driver) }
+    }
+
+    #[inline(always)]
+    fn event_and_driver(self: Pin<&mut Self>) -> (&mut E, Pin<&mut S>) {
+        unsafe {
+            let this: &mut Submission<E, S> = Pin::get_unchecked_mut(self);
+            (&mut this.event, Pin::new_unchecked(&mut this.driver))
         }
     }
 }
@@ -55,48 +92,81 @@ impl<E, S> Future for Submission<E, S> where
 {
     type Output = (E, io::Result<usize>);
 
-    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         unsafe {
-            let this: &mut Submission<E, S> = Pin::get_unchecked_mut(self);
-            
-            // If we still have a completion, this future is not finished.
-            if let Some(completion) = &mut this.completion {
-                // Check the completion. If it has completed, this future is ready.
-                // Drop the completion and return the event and the result.
-                if let Some(result) = completion.as_ref().check() {
-                    drop(Box::<Completion>::from_raw(completion.as_ptr()));
-                    this.completion = None;
-                    let event = ManuallyDrop::take(&mut this.event);
-                    Poll::Ready((event, result))
-                }
-
-                // Otherwise, check if this future needs to be submitted.
-                // If so, set the completion's waker to wake this future
-                // and ensure submission.
-                else if let Some(mut submitter) = this.submitter.take() {
-                    completion.as_mut().set_waker(ctx.waker().clone());
-                    // TODO how could we report this error?
-                    let _ = submitter.submit();
+            match self.state {
+                // In the waiting state, first attempt to prepare the event
+                // for submission. If that succeeds, also attempt to submit it.
+                State::Waiting     => {
+                    if let Poll::Ready(()) = self.as_mut().try_prepare(ctx) {
+                        self.as_mut().try_submit(ctx);
+                    }
                     Poll::Pending
                 }
 
-                // If not, this was a spurious wake up, just return pending.
-                else {
-                    Poll::Pending
+                // If the event has been prepared but not submitted, first
+                // try to complete it to check if it has been opportunistically
+                // opportunistically submitted elsewhere. If not, attempt to
+                // submit the event.
+                State::Prepared    => {
+                    match self.as_mut().try_complete(ctx) {
+                        ready @ Poll::Ready(..) => ready,
+                        Poll::Pending           => {
+                            self.as_mut().try_submit(ctx);
+                            Poll::Pending
+                        }
+                    }
                 }
-            } else {
-                panic!("Submission future polled after completion finished")
+
+                // If the event is submitted, there is no work but to try to
+                // complete it.
+                State::Submitted   => self.try_complete(ctx),
+
+                // If the event is completed, this future has been called after
+                // returning ready.
+                State::Complete    => panic!("Submission future polled after completion finished"),
             }
         }
     }
 }
+
 
 impl<E: Event, S> Drop for Submission<E, S> {
     fn drop(&mut self) {
-        if let Some(completion) = self.completion {
+        if matches!(self.state, State::Prepared | State::Submitted) {
             unsafe {
-                completion.as_ref().cancel(Event::cancellation(&mut self.event))
+                self.completion.as_ref().cancel(Event::cancellation(&mut self.event));
             }
         }
     }
 }
+
+#[inline(always)]
+unsafe fn prepare<E: Event>(
+    sqe: iou::SubmissionQueueEvent<'_>,
+    ctx: &mut Context<'_>,
+    event: &mut E
+) -> NonNull<Completion> {
+    // Use the SubmissionCleaner guard to clear the submission of any data
+    // in case the Event::prepare method panics
+    struct SubmissionCleaner<'a>(iou::SubmissionQueueEvent<'a>);
+
+    impl<'a> Drop for SubmissionCleaner<'a> {
+        fn drop(&mut self) {
+            unsafe {
+                self.0.prep_nop();
+                self.0.set_user_data(0);
+            }
+        }
+    }
+
+    let mut sqe = SubmissionCleaner(sqe);
+    event.prepare(&mut sqe.0);
+
+    let completion = Box::new(Completion::new(ctx.waker().clone()));
+    let completion = NonNull::new_unchecked(Box::into_raw(completion));
+    sqe.0.set_user_data(completion.as_ptr() as usize as u64);
+    mem::forget(sqe);
+    completion
+}
+


### PR DESCRIPTION
The Submit traits two methods now have a poll-based interface, which
allows them to fail to prepare or submit an event, applying
backpressure when necessary.

The example driver, which is very bad in many ways, does not actually
apply backpressure right now.

This also involves a complete rewrite of the Submission future's
internals, to make it more explicitly a state machine. It also means
that the submission is *not* prepared until the future starts polling.
This is more consistent with the behavior of Rust's futures in general,
but it means that there's no way for individual events to indicate that
they should not be eagerly submitted. That will need to change later.