### PR TITLE
Add Ring interface.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,3 @@ branch = "new-apis-needed-for-ringbahn"
 
 [dev-dependencies]
 futures = "0.3.5"
-
-[features]
-nightly = []
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ branch = "new-apis-needed-for-ringbahn"
 [dev-dependencies]
 async-std = "1.5.0"
 futures = "0.3.5"
+
+[features]
+nightly = []
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ git = "https://github.com/withoutboats/iou"
 branch = "new-apis-needed-for-ringbahn"
 
 [dev-dependencies]
-async-std = "1.5.0"
 futures = "0.3.5"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 [dependencies]
 parking_lot = "0.10.2"
 once_cell = "1.3.1"
+futures-io = "0.3.5"
+futures-core = "0.3.5"
 
 [dependencies.iou]
 git = "https://github.com/withoutboats/iou"
@@ -16,3 +18,4 @@ branch = "new-apis-needed-for-ringbahn"
 
 [dev-dependencies]
 async-std = "1.5.0"
+futures = "0.3.5"

--- a/examples/copy-file.rs
+++ b/examples/copy-file.rs
@@ -1,0 +1,17 @@
+use std::fs::File;
+
+use futures::io::AsyncReadExt;
+use futures::io::AsyncWriteExt;
+
+use ringbahn::Ring;
+
+fn main() {
+    let mut input:  Ring<File> = Ring::new(File::open("props.txt").unwrap());
+    let mut output: Ring<File> = Ring::new(File::create("test.txt").unwrap());
+    futures::executor::block_on(async move {
+        let mut buf = vec![0; 1024];
+        let len = input.read(&mut buf).await.unwrap();
+        output.write(&mut buf[0..len]).await.unwrap();
+        output.flush().await.unwrap();
+    });
+}

--- a/props.txt
+++ b/props.txt
@@ -1,1 +1,9 @@
-But this formidable power of death - and this is perhaps what accounts for part of its force and the cynicism with which it has so greatly expanded its limits - now presents itself as the counterpart of a power that exerts a positive influence on life, that endeavors to administer, optimize, and multiply it, subjecting it to precise controls and comprehensive regulations. Wars are no longer waged in the name of a sovereign who must be defended; they are waged on behalf of the existence of everyone; entire populations are mobilized for the purpose of wholesale slaughter in the name of life necessity: massacres have become vital. It is as managers of life and survival, of bodies and the race, that so many regimes have been able to wage so many wars, causing so many men to be killed.
+But this formidable power of death - and this is perhaps what accounts for part of its force and
+the cynicism with which it has so greatly expanded its limits - now presents itself as the
+counterpart of a power that exerts a positive influence on life, that endeavors to administer,
+optimize, and multiply it, subjecting it to precise controls and comprehensive regulations. Wars
+are no longer waged in the name of a sovereign who must be defended; they are waged on behalf of
+the existence of everyone; entire populations are mobilized for the purpose of wholesale slaughter
+in the name of life necessity: massacres have become vital. It is as managers of life and survival,
+of bodies and the race, that so many regimes have been able to wage so many wars, causing so many
+men to be killed.

--- a/src/driver/completion.rs
+++ b/src/driver/completion.rs
@@ -24,7 +24,7 @@ impl Completion {
         }
     }
 
-    pub(crate) fn set_waker(&mut self, waker: Waker) {
+    pub(crate) fn set_waker(&self, waker: Waker) {
         let mut state = self.state.lock();
         if let State::Submitted(slot) = &mut *state {
             *slot = waker;

--- a/src/driver/toy.rs
+++ b/src/driver/toy.rs
@@ -19,6 +19,12 @@ pub struct Driver {
     driver: Lazy<Mutex<iou::SubmissionQueue<'static>>>,
 }
 
+impl Default for &'_ Driver {
+    fn default() -> Self {
+        &DRIVER
+    }
+}
+
 impl<'a> Drive for &'a Driver {
     fn poll_prepare(
         self: Pin<&mut Self>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(read_initializer)]
+#![cfg_attr(feature = "nightly", feature(read_initializer))]
 
 pub mod driver;
 pub mod event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,13 @@
-mod submission;
+#![feature(read_initializer)]
 
 pub mod driver;
 pub mod event;
+
+mod ring;
+mod submission;
 
 pub use submission::Submission;
 
 pub use driver::Drive;
 pub use event::Event;
+pub use ring::Ring;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(read_initializer))]
-
 pub mod driver;
 pub mod event;
 

--- a/src/ring/engine.rs
+++ b/src/ring/engine.rs
@@ -1,0 +1,237 @@
+use futures_core::ready;
+
+use std::io;
+use std::mem;
+use std::os::unix::io::RawFd;
+use std::pin::Pin;
+use std::ptr::NonNull;
+use std::task::{Context, Poll};
+
+use crate::event::Cancellation;
+use crate::driver::{Drive, Completion};
+
+use State::*;
+
+pub struct Engine<D> {
+    state: State,
+    completion: NonNull<Completion>,
+    driver: D,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum State {
+    Inert,
+    WaitingRead,
+    PreparedRead,
+    SubmittedRead,
+    WaitingWrite,
+    PreparedWrite,
+    SubmittedWrite,
+}
+
+impl<D: Drive> Engine<D> {
+    pub fn new(driver: D) -> Engine<D> {
+        Engine {
+            state: Inert,
+            completion: NonNull::dangling(),
+            driver,
+        }
+    }
+
+    /// Safety: caller must ensure unique ownership of both fd and the backing buffer
+    pub unsafe fn poll_read(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        fd: RawFd,
+        buf: &mut [u8]
+    ) -> Poll<io::Result<usize>> {
+        match self.state {
+            Inert | WaitingRead                             => {
+                *self.as_mut().state() = WaitingRead;
+                ready!(self.as_mut().try_prepare(ctx, fd, buf, |sqe, ctx, io, buf| {
+                    prepare_read(sqe, ctx, io, buf)
+                }));
+                ready!(self.as_mut().try_submit(ctx));
+                Poll::Pending
+            }
+            PreparedRead                                    => {
+                match self.as_mut().try_complete(ctx) {
+                    ready @ Poll::Ready(..) => ready,
+                    Poll::Pending           => {
+                        ready!(self.as_mut().try_submit(ctx));
+                        Poll::Pending
+                    }
+                }
+            }
+            SubmittedRead                                   => {
+                self.as_mut().try_complete(ctx)
+            }
+            WaitingWrite | PreparedWrite | SubmittedWrite   => {
+                panic!("attempted simultaneous read and write on same object")
+            }
+        }
+    }
+
+    /// Safety: caller must ensure unique ownership of both fd and the backing buffer
+    #[allow(dead_code)]
+    pub unsafe fn poll_write(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        fd: RawFd,
+        buf: &[u8]
+    ) -> Poll<io::Result<usize>> {
+        match self.state {
+            Inert | WaitingWrite                        => {
+                *self.as_mut().state() = WaitingWrite;
+                ready!(self.as_mut().try_prepare(ctx, fd, buf, |sqe, ctx, io, buf| {
+                    prepare_write(sqe, ctx, io, buf)
+                }));
+                ready!(self.as_mut().try_submit(ctx));
+                Poll::Pending
+            }
+            PreparedWrite                               => {
+                match self.as_mut().try_complete(ctx) {
+                    ready @ Poll::Ready(..) => ready,
+                    Poll::Pending           => {
+                        ready!(self.as_mut().try_submit(ctx));
+                        Poll::Pending
+                    }
+                }
+            }
+            SubmittedWrite                              => {
+                self.as_mut().try_complete(ctx)
+            }
+            WaitingRead | PreparedRead | SubmittedRead  => {
+                panic!("attempted simultaneous read and write on same object")
+            }
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn try_prepare<T, F>(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        fd: RawFd,
+        buf: T,
+        prepare: F,
+    ) -> Poll<()> where
+        F: FnOnce(iou::SubmissionQueueEvent<'_>, &mut Context<'_>, RawFd, T) -> NonNull<Completion>
+    {
+        let driver = self.as_mut().driver();
+        let completion = ready!(driver.poll_prepare(ctx, |sqe, ctx| prepare(sqe, ctx, fd, buf)));
+        *self.as_mut().completion() = completion;
+        self.as_mut().state().prepare();
+        Poll::Ready(())
+    }
+
+    #[inline(always)]
+    unsafe fn try_submit(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<()> {
+        // TODO figure out how to handle this result
+        let _ = ready!(self.as_mut().driver().poll_submit(ctx, true));
+        self.as_mut().state().submit();
+        Poll::Pending
+    }
+
+    #[inline(always)]
+    unsafe fn try_complete(mut self: Pin<&mut Self>, ctx: &mut Context<'_>)
+        -> Poll<io::Result<usize>>
+    {
+        if let Some(result) = self.as_mut().completion().as_ref().check() {
+            *self.as_mut().state() = Inert;
+            drop(Box::<Completion>::from_raw(self.as_mut().completion().as_ptr()));
+            Poll::Ready(result)
+        } else {
+            self.as_mut().completion().as_ref().set_waker(ctx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    #[inline(always)]
+    fn driver(self: Pin<&mut Self>) -> Pin<&mut D> {
+        unsafe { Pin::map_unchecked_mut(self, |this| &mut this.driver) }
+    }
+
+    #[inline(always)]
+    fn state(self: Pin<&mut Self>) -> &mut State {
+        unsafe { &mut Pin::get_unchecked_mut(self).state }
+    }
+
+    #[inline(always)]
+    fn completion(self: Pin<&mut Self>) -> &mut NonNull<Completion> {
+        unsafe { &mut Pin::get_unchecked_mut(self).completion }
+    }
+}
+
+
+impl<D> Engine<D> {
+    // this must be the correct cancellation callback for the event currently being driven
+    pub unsafe fn cancel(&mut self, cancellation: Cancellation) {
+        if matches!(self.state, PreparedRead | PreparedWrite | SubmittedRead | SubmittedWrite) {
+            self.completion.as_ref().cancel(cancellation);
+        }
+    }
+}
+
+impl State {
+    #[inline(always)]
+    fn prepare(&mut self) {
+        match self {
+            WaitingRead     => *self = PreparedRead,
+            WaitingWrite    => *self = PreparedWrite,
+            _               => (),
+        }
+    }
+    #[inline(always)]
+    fn submit(&mut self) {
+        match self {
+            PreparedRead    => *self = SubmittedRead,
+            PreparedWrite   => *self = SubmittedWrite,
+            _               => (),
+        }
+    }
+}
+
+unsafe fn prepare_read(
+    sqe: iou::SubmissionQueueEvent<'_>,
+    ctx: &mut Context<'_>, 
+    fd: RawFd,
+    buf: &mut [u8],
+) -> NonNull<Completion> {
+    let mut sqe = SubmissionCleaner(sqe);
+    sqe.0.prep_read(fd, buf, 0);
+
+    let completion = Box::new(Completion::new(ctx.waker().clone()));
+    let completion = NonNull::new_unchecked(Box::into_raw(completion));
+    sqe.0.set_user_data(completion.as_ptr() as usize as u64);
+    mem::forget(sqe);
+    completion
+}
+
+unsafe fn prepare_write(
+    sqe: iou::SubmissionQueueEvent<'_>,
+    ctx: &mut Context<'_>, 
+    fd: RawFd,
+    buf: &[u8],
+) -> NonNull<Completion> {
+    let mut sqe = SubmissionCleaner(sqe);
+    sqe.0.prep_write(fd, buf, 0);
+
+    let completion = Box::new(Completion::new(ctx.waker().clone()));
+    let completion = NonNull::new_unchecked(Box::into_raw(completion));
+    sqe.0.set_user_data(completion.as_ptr() as usize as u64);
+    mem::forget(sqe);
+    completion
+}
+
+// Use the SubmissionCleaner guard to clear the submission of any data
+// in case the Event::prepare method panics
+struct SubmissionCleaner<'a>(iou::SubmissionQueueEvent<'a>);
+
+impl<'a> Drop for SubmissionCleaner<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            self.0.prep_nop();
+            self.0.set_user_data(0);
+        }
+    }
+}

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -82,15 +82,21 @@ struct Buffer {
 }
 
 impl Buffer {
-    fn new<IO: io::Read>(io: &IO) -> Buffer {
+    fn new<IO: io::Read>(#[allow(unused_variables)] io: &IO) -> Buffer {
         unsafe {
             const CAPACITY: usize = 1024 * 8;
             let mut buf = Vec::with_capacity(CAPACITY);
             buf.set_len(CAPACITY);
 
-            let initializer = io.initializer();
-            if initializer.should_initialize() {
-                initializer.initialize(&mut buf[..]);
+            #[cfg(feature = "nightly")] {
+                let initializer = io.initializer();
+                if initializer.should_initialize() {
+                    initializer.initialize(&mut buf[..]);
+                }
+            }
+
+            #[cfg(not(feature = "nightly"))] {
+                std::ptr::write_bytes(buf.as_mut_ptr(), 0, CAPACITY)
             }
 
             Buffer {

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -69,9 +69,8 @@ impl<IO: io::Read + AsRawFd, D: Drive> AsyncRead for Ring<IO, D> {
         -> Poll<io::Result<usize>>
     {
         match self.as_mut().poll_fill_buf(ctx) {
-            Poll::Ready(Ok(inner))  => {
-                let len = cmp::min(inner.len(), buf.len());
-                buf[0..len].copy_from_slice(&inner[0..len]);
+            Poll::Ready(Ok(mut inner))  => {
+                let len = io::Read::read(&mut inner, buf)?;
                 self.as_mut().consume(len);
                 Poll::Ready(Ok(len))
             }

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -1,23 +1,27 @@
 mod engine;
 
-use std::cmp;
 use std::io;
 use std::os::unix::io::AsRawFd;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_core::ready;
-use futures_io::{AsyncRead, AsyncBufRead};
+use futures_io::{AsyncRead, AsyncBufRead, AsyncWrite};
 
-use crate::event::Cancellation;
 use crate::driver::{Drive, Driver};
 
 use engine::Engine;
 
+pub trait AsyncBufWrite {
+    fn poll_partial_flush_buf(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<&mut [u8]>>;
+
+    fn produce(self: Pin<&mut Self>, amt: usize);
+}
+
 pub struct Ring<IO, D = &'static Driver> {
-    engine: Engine<D>,
+    engine: Engine,
     io: IO,
-    buf: Buffer,
+    driver: D,
 }
 
 impl<IO: AsRawFd + io::Read, D: Drive + Default> Ring<IO, D> {
@@ -29,38 +33,33 @@ impl<IO: AsRawFd + io::Read, D: Drive + Default> Ring<IO, D> {
 impl<IO: AsRawFd + io::Read, D: Drive> Ring<IO, D> {
     pub fn on_driver(io: IO, driver: D) -> Ring<IO, D> {
         Ring {
-            engine: Engine::new(driver),
-            buf: Buffer::new(&io),
-            io, 
+            engine: Engine::new(&io),
+            io, driver,
         }
     }
+}
 
-    fn split(self: Pin<&mut Self>) -> (&mut Buffer, Pin<&mut IO>, Pin<&mut Engine<D>>) {
+impl<IO, D> Ring<IO, D> {
+    fn split(self: Pin<&mut Self>) -> (&mut Engine, Pin<&mut IO>, Pin<&mut D>) {
         unsafe {
             let this = Pin::get_unchecked_mut(self);
-            (&mut this.buf, Pin::new_unchecked(&mut this.io), Pin::new_unchecked(&mut this.engine))
+            let engine = &mut this.engine;
+            let io = Pin::new_unchecked(&mut this.io);
+            let driver = Pin::new_unchecked(&mut this.driver);
+            (engine, io, driver)
         }
-    }
-
-    fn buffer(self: Pin<&mut Self>) -> &mut Buffer {
-        unsafe { &mut Pin::get_unchecked_mut(self).buf }
     }
 }
 
 impl<IO: io::Read + AsRawFd, D: Drive> AsyncBufRead for Ring<IO, D> {
     fn poll_fill_buf(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-        let (buf, io, engine) = self.split();
-        if buf.pos >= buf.cap {
-            buf.cap = unsafe {
-                ready!(engine.poll_read(ctx, io.as_raw_fd(), &mut buf.buf[..]))?
-            };
-            buf.pos = 0;
-        }
-        Poll::Ready(Ok(&buf.buf[buf.pos..buf.cap]))
+        let (engine, io, driver) = self.split();
+        engine.poll_fill_read_buf(ctx, driver, io.as_raw_fd())
     }
     
     fn consume(self: Pin<&mut Self>, amt: usize) {
-        self.buffer().consume(amt);
+        let (engine, ..) = self.split();
+        engine.consume(amt);
     }
 }
 
@@ -68,61 +67,42 @@ impl<IO: io::Read + AsRawFd, D: Drive> AsyncRead for Ring<IO, D> {
     fn poll_read(mut self: Pin<&mut Self>, ctx: &mut Context<'_>, buf: &mut [u8])
         -> Poll<io::Result<usize>>
     {
-        match self.as_mut().poll_fill_buf(ctx) {
-            Poll::Ready(Ok(mut inner))  => {
-                let len = io::Read::read(&mut inner, buf)?;
-                self.as_mut().consume(len);
-                Poll::Ready(Ok(len))
-            }
-            Poll::Ready(Err(err))   => Poll::Ready(Err(err)),
-            Poll::Pending           => Poll::Pending,
-        }
+        let mut inner = ready!(self.as_mut().poll_fill_buf(ctx))?;
+        let len = io::Read::read(&mut inner, buf)?;
+        self.consume(len);
+        Poll::Ready(Ok(len))
     }
 }
 
-struct Buffer {
-    buf: Box<[u8]>,
-    pos: usize,
-    cap: usize,
-}
-
-impl Buffer {
-    fn new<IO: io::Read>(#[allow(unused_variables)] io: &IO) -> Buffer {
-        unsafe {
-            const CAPACITY: usize = 1024 * 8;
-            let mut buf = Vec::with_capacity(CAPACITY);
-            buf.set_len(CAPACITY);
-
-            #[cfg(feature = "nightly")] {
-                let initializer = io.initializer();
-                if initializer.should_initialize() {
-                    initializer.initialize(&mut buf[..]);
-                }
-            }
-
-            #[cfg(not(feature = "nightly"))] {
-                std::ptr::write_bytes(buf.as_mut_ptr(), 0, CAPACITY)
-            }
-
-            Buffer {
-                buf: buf.into_boxed_slice(),
-                pos: 0,
-                cap: 0,
-            }
-        }
+impl<IO: io::Write + AsRawFd, D: Drive> AsyncBufWrite for Ring<IO, D> {
+    fn poll_partial_flush_buf(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<&mut [u8]>> {
+        let (engine, io, driver) = self.split();
+        engine.poll_partial_flush_write_buf(ctx, driver, io.as_raw_fd())
     }
 
-    fn consume(&mut self, amt: usize) {
-        self.pos = cmp::min(self.pos + amt, self.cap);
+    fn produce(self: Pin<&mut Self>, amt: usize) {
+        let (engine, ..) = self.split();
+        engine.produce(amt);
     }
 }
 
-impl<IO, D> Drop for Ring<IO, D> {
-    fn drop(&mut self) {
-        unsafe {
-            let data = self.buf.buf.as_mut_ptr();
-            let len = self.buf.buf.len();
-            self.engine.cancel(Cancellation::buffer(data, len));
-        }
+impl<IO: io::Write + AsRawFd, D: Drive> AsyncWrite for Ring<IO, D> {
+    fn poll_write(mut self: Pin<&mut Self>, ctx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        // TODO consider only flushing if strictly necessary
+        let mut inner = ready!(self.as_mut().poll_partial_flush_buf(ctx))?;
+        let len = io::Write::write(&mut inner, buf)?;
+        self.produce(len);
+        Poll::Ready(Ok(len))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let (engine, io, driver) = self.split();
+        engine.poll_flush_write_buf(ctx, driver, io.as_raw_fd())
+    }
+
+    fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // TODO close underlying fd
+        let (engine, io, driver) = self.split();
+        engine.poll_flush_write_buf(ctx, driver, io.as_raw_fd())
     }
 }

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -10,18 +10,24 @@ use futures_core::ready;
 use futures_io::{AsyncRead, AsyncBufRead};
 
 use crate::event::Cancellation;
-use crate::driver::Drive;
+use crate::driver::{Drive, Driver};
 
 use engine::Engine;
 
-pub struct Ring<IO, D> {
+pub struct Ring<IO, D = &'static Driver> {
     engine: Engine<D>,
     io: IO,
     buf: Buffer,
 }
 
+impl<IO: AsRawFd + io::Read, D: Drive + Default> Ring<IO, D> {
+    pub fn new(io: IO) -> Ring<IO, D> {
+        Ring::on_driver(io, D::default())
+    }
+}
+
 impl<IO: AsRawFd + io::Read, D: Drive> Ring<IO, D> {
-    pub fn new(io: IO, driver: D) -> Ring<IO, D> {
+    pub fn on_driver(io: IO, driver: D) -> Ring<IO, D> {
         Ring {
             engine: Engine::new(driver),
             buf: Buffer::new(&io),

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -1,0 +1,117 @@
+mod engine;
+
+use std::cmp;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::ready;
+use futures_io::{AsyncRead, AsyncBufRead};
+
+use crate::event::Cancellation;
+use crate::driver::Drive;
+
+use engine::Engine;
+
+pub struct Ring<IO, D> {
+    engine: Engine<D>,
+    io: IO,
+    buf: Buffer,
+}
+
+impl<IO: AsRawFd + io::Read, D: Drive> Ring<IO, D> {
+    pub fn new(io: IO, driver: D) -> Ring<IO, D> {
+        Ring {
+            engine: Engine::new(driver),
+            buf: Buffer::new(&io),
+            io, 
+        }
+    }
+
+    fn split(self: Pin<&mut Self>) -> (&mut Buffer, Pin<&mut IO>, Pin<&mut Engine<D>>) {
+        unsafe {
+            let this = Pin::get_unchecked_mut(self);
+            (&mut this.buf, Pin::new_unchecked(&mut this.io), Pin::new_unchecked(&mut this.engine))
+        }
+    }
+
+    fn buffer(self: Pin<&mut Self>) -> &mut Buffer {
+        unsafe { &mut Pin::get_unchecked_mut(self).buf }
+    }
+}
+
+impl<IO: io::Read + AsRawFd, D: Drive> AsyncBufRead for Ring<IO, D> {
+    fn poll_fill_buf(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let (buf, io, engine) = self.split();
+        if buf.pos >= buf.cap {
+            buf.cap = unsafe {
+                ready!(engine.poll_read(ctx, io.as_raw_fd(), &mut buf.buf[..]))?
+            };
+            buf.pos = 0;
+        }
+        Poll::Ready(Ok(&buf.buf[buf.pos..buf.cap]))
+    }
+    
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.buffer().consume(amt);
+    }
+}
+
+impl<IO: io::Read + AsRawFd, D: Drive> AsyncRead for Ring<IO, D> {
+    fn poll_read(mut self: Pin<&mut Self>, ctx: &mut Context<'_>, buf: &mut [u8])
+        -> Poll<io::Result<usize>>
+    {
+        match self.as_mut().poll_fill_buf(ctx) {
+            Poll::Ready(Ok(inner))  => {
+                let len = cmp::min(inner.len(), buf.len());
+                buf[0..len].copy_from_slice(&inner[0..len]);
+                self.as_mut().consume(len);
+                Poll::Ready(Ok(len))
+            }
+            Poll::Ready(Err(err))   => Poll::Ready(Err(err)),
+            Poll::Pending           => Poll::Pending,
+        }
+    }
+}
+
+struct Buffer {
+    buf: Box<[u8]>,
+    pos: usize,
+    cap: usize,
+}
+
+impl Buffer {
+    fn new<IO: io::Read>(io: &IO) -> Buffer {
+        unsafe {
+            const CAPACITY: usize = 1024 * 8;
+            let mut buf = Vec::with_capacity(CAPACITY);
+            buf.set_len(CAPACITY);
+
+            let initializer = io.initializer();
+            if initializer.should_initialize() {
+                initializer.initialize(&mut buf[..]);
+            }
+
+            Buffer {
+                buf: buf.into_boxed_slice(),
+                pos: 0,
+                cap: 0,
+            }
+        }
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.pos = cmp::min(self.pos + amt, self.cap);
+    }
+}
+
+impl<IO, D> Drop for Ring<IO, D> {
+    fn drop(&mut self) {
+        unsafe {
+            let data = self.buf.buf.as_mut_ptr();
+            let len = self.buf.buf.len();
+            self.engine.cancel(Cancellation::buffer(data, len));
+        }
+    }
+}

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -64,7 +64,7 @@ impl<E: Event, D: Drive> Submission<E, D> {
             let event = ManuallyDrop::take(&mut this.event);
             Poll::Ready((event, result))
         } else {
-            this.completion.as_mut().set_waker(ctx.waker().clone());
+            this.completion.as_ref().set_waker(ctx.waker().clone());
             Poll::Pending
         }
     }

--- a/tests/basic-read.rs
+++ b/tests/basic-read.rs
@@ -9,7 +9,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 fn read_file() {
     let mut file = File::open("props.txt").unwrap();
     let read: Read<'_, File> = Read::new(&mut file, vec![0; 4096]);
-    let (read, result) = async_std::task::block_on(async move { read.submit(&DRIVER).await });
+    let (read, result) = futures::executor::block_on(async move { read.submit(&DRIVER).await });
     assert!(result.is_ok());
     assert_eq!(&read.buf[0..ASSERT.len()], ASSERT);
 }

--- a/tests/ring-read.rs
+++ b/tests/ring-read.rs
@@ -11,7 +11,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 fn read_file() {
     let file = File::open("props.txt").unwrap();
     let mut file: Ring<File, _> = Ring::new(file, &DRIVER);
-    async_std::task::block_on(async move {
+    futures::executor::block_on(async move {
         let mut buf = vec![0; 4096];
         assert!(file.read(&mut buf).await.is_ok());
         assert_eq!(&buf[0..ASSERT.len()], ASSERT);

--- a/tests/ring-read.rs
+++ b/tests/ring-read.rs
@@ -3,14 +3,13 @@ use std::fs::File;
 use futures::AsyncReadExt;
 
 use ringbahn::Ring;
-use ringbahn::driver::DRIVER;
 
 const ASSERT: &[u8] = b"But this formidable power of death -";
 
 #[test]
 fn read_file() {
     let file = File::open("props.txt").unwrap();
-    let mut file: Ring<File, _> = Ring::new(file, &DRIVER);
+    let mut file: Ring<File> = Ring::new(file);
     futures::executor::block_on(async move {
         let mut buf = vec![0; 4096];
         assert!(file.read(&mut buf).await.is_ok());

--- a/tests/ring-read.rs
+++ b/tests/ring-read.rs
@@ -1,0 +1,19 @@
+use std::fs::File;
+
+use futures::AsyncReadExt;
+
+use ringbahn::Ring;
+use ringbahn::driver::DRIVER;
+
+const ASSERT: &[u8] = b"But this formidable power of death -";
+
+#[test]
+fn read_file() {
+    let file = File::open("props.txt").unwrap();
+    let mut file: Ring<File, _> = Ring::new(file, &DRIVER);
+    async_std::task::block_on(async move {
+        let mut buf = vec![0; 4096];
+        assert!(file.read(&mut buf).await.is_ok());
+        assert_eq!(&buf[0..ASSERT.len()], ASSERT);
+    });
+}


### PR DESCRIPTION
The `Ring` interface wraps a normal IO object and runs its io on an io-uring driver. It is intended to be the simplest high level API for using io-uring.

### The API

The Ring type takes an IO object and a driver to create a new async IO object. The new object implements AsyncRead, AsyncBufRead, and AsyncWrite. A simple test of reading is demonstrated in `tests/ring-read.rs` and an example of both reading and writing is found in `examples/copy-file.rs`.

Some quirks remain:

* Opening and closing are still performed blocking. `AsyncWrite::poll_close` just flushes.
* If you drop a write and then start a new write, the old write will continue instead of the new one.

Surely there are many bugs.

### Buffer management

The Ring type currently manages buffers by implementing a direct copy of the BufReader type from std and futures, meaning it owns a buffer which it uses again and again. This is far from the best design, and different designs would be well-suited to different use cases. We should support
different buffer management strategies on the ring, introducing a third parameter to the type. This needs further investigation as well.