### PR TITLE
Fix some memory bugs

### DIFF
--- a/src/ring/engine.rs
+++ b/src/ring/engine.rs
@@ -5,6 +5,7 @@ use std::io;
 use std::mem;
 use std::os::unix::io::RawFd;
 use std::pin::Pin;
+use std::ptr;
 use std::task::{Context, Poll};
 
 use crate::completion::Completion;
@@ -131,14 +132,14 @@ impl Engine {
                     let data = self.read_buf.buf.as_mut_ptr();
                     let len = self.read_buf.buf.len();
                     self.completion.cancel(Cancellation::buffer(data, len));
-                    self.read_buf = Buffer::new();
+                    ptr::write(&mut self.read_buf, Buffer::new());
                     self.state = Inert;
                 }
                 WritePrepared | WriteSubmitted  => {
                     let data = self.write_buf.buf.as_mut_ptr();
                     let len = self.write_buf.buf.len();
                     self.completion.cancel(Cancellation::buffer(data, len));
-                    self.write_buf = Buffer::new();
+                    ptr::write(&mut self.read_buf, Buffer::new());
                     self.state = Inert;
                 }
                 WriteBuffered                   => {

--- a/src/ring/engine.rs
+++ b/src/ring/engine.rs
@@ -139,7 +139,7 @@ impl Engine {
                     let data = self.write_buf.buf.as_mut_ptr();
                     let len = self.write_buf.buf.len();
                     self.completion.cancel(Cancellation::buffer(data, len));
-                    ptr::write(&mut self.read_buf, Buffer::new());
+                    ptr::write(&mut self.write_buf, Buffer::new());
                     self.state = Inert;
                 }
                 WriteBuffered                   => {

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -134,7 +134,7 @@ impl<E, D> Future for Submission<E, D> where
 
 impl<E: Event, D> Drop for Submission<E, D> {
     fn drop(&mut self) {
-        if matches!(self.state, State::Prepared | State::Submitted | State::Lost) {
+        if matches!(self.state, State::Prepared | State::Submitted) {
             unsafe {
                 self.completion.cancel(Event::cancellation(&mut self.event));
             }


### PR DESCRIPTION
* Ring's cancellation double freed the buffer
* Submission ManuallyDrops the driver for no reason (and previously leaked it if the submission was cancelled)