### PR TITLE
Tests for write ops & bugfixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 access-queue = "1.1.0"
 futures-io = "0.3.5"
 futures-core = "0.3.5"
-iou = { path = "../iou" }
+iou = "0.0.0-ringbahn.1"
 parking_lot = "0.10.2"
 once_cell = "1.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ edition = "2018"
 access-queue = "1.1.0"
 futures-io = "0.3.5"
 futures-core = "0.3.5"
-iou = "0.0.0-ringbahn.1"
+iou = { path = "../iou" }
 parking_lot = "0.10.2"
 once_cell = "1.3.1"
 
 [dev-dependencies]
+tempfile = "3.1.0"
 futures = "0.3.5"

--- a/src/ring/engine.rs
+++ b/src/ring/engine.rs
@@ -193,7 +193,7 @@ impl Engine {
     {
         // TODO figure out how to handle this result
         let _ = ready!(driver.poll_submit(ctx, true));
-        Poll::Pending
+        Poll::Ready(())
     }
 
     #[inline(always)]

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -45,6 +45,10 @@ impl<IO: AsRawFd, D: Drive> Ring<IO, D> {
     pub fn cancel(&mut self) {
         self.engine.cancel();
     }
+
+    pub fn blocking(&mut self) -> &mut IO {
+        &mut self.io
+    }
 }
 
 impl<IO, D> Ring<IO, D> {

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -58,7 +58,7 @@ impl<E: Event, D: Drive> Submission<E, D> {
         // TODO figure out how to handle this result
         let _ = ready!(driver.poll_submit(ctx, event.is_eager()));
         Pin::get_unchecked_mut(self).state = State::Submitted;
-        Poll::Pending
+        Poll::Ready(())
     }
 
     #[inline(always)]

--- a/tests/basic-write.rs
+++ b/tests/basic-write.rs
@@ -1,0 +1,20 @@
+use std::fs::File;
+use std::io::Read;
+
+use ringbahn::Submission;
+use ringbahn::event::Write;
+use ringbahn::drive::demo;
+
+const ASSERT: &[u8] = b"But this formidable power of death -";
+
+#[test]
+fn write_file() {
+    let mut file = tempfile::tempfile().unwrap();
+    let write: Write<'_, File> = Write::new(&mut file, Vec::from(ASSERT));
+    let (_, result) = futures::executor::block_on(Submission::new(write, demo::driver()));
+    assert_eq!(result.unwrap(), ASSERT.len());
+
+    let mut buf = vec![];
+    assert_eq!(file.read_to_end(&mut buf).unwrap(), ASSERT.len());
+    assert_eq!(&buf[0..ASSERT.len()], ASSERT);
+}

--- a/tests/ring-write.rs
+++ b/tests/ring-write.rs
@@ -1,0 +1,21 @@
+use std::fs::File;
+use std::io::Read;
+
+use futures::AsyncWriteExt;
+
+use ringbahn::Ring;
+
+const ASSERT: &[u8] = b"But this formidable power of death -";
+
+#[test]
+fn read_file() {
+    let file = tempfile::tempfile().unwrap();
+    let mut file: Ring<File> = Ring::new(file);
+    futures::executor::block_on(async move {
+        assert_eq!(file.write(ASSERT).await.unwrap(), ASSERT.len());
+
+        let mut buf = vec![];
+        assert_eq!(file.blocking().read_to_end(&mut buf).unwrap(), ASSERT.len());
+        assert_eq!(&buf[0..ASSERT.len()], ASSERT);
+    });
+}

--- a/tests/ring-write.rs
+++ b/tests/ring-write.rs
@@ -8,7 +8,7 @@ use ringbahn::Ring;
 const ASSERT: &[u8] = b"But this formidable power of death -";
 
 #[test]
-fn read_file() {
+fn write_file() {
     let file = tempfile::tempfile().unwrap();
     let mut file: Ring<File> = Ring::new(file);
     futures::executor::block_on(async move {

--- a/tests/ring-write.rs
+++ b/tests/ring-write.rs
@@ -19,3 +19,38 @@ fn write_file() {
         assert_eq!(&buf[0..ASSERT.len()], ASSERT);
     });
 }
+
+#[test]
+fn select_complete_many_futures() {
+    async fn act() {
+        let file = tempfile::tempfile().unwrap();
+        let mut file: Ring<File> = Ring::new(file);
+        file.write_all(b"hello, world!").await.unwrap();
+    }
+
+    futures::executor::block_on(async move {
+        use futures::FutureExt;
+
+        let mut f1 = Box::pin(act().fuse());
+        let mut f2 = Box::pin(act().fuse());
+        let mut f3 = Box::pin(act().fuse());
+        let mut f4 = Box::pin(act().fuse());
+        let mut f5 = Box::pin(act().fuse());
+        let mut f6 = Box::pin(act().fuse());
+        let mut f7 = Box::pin(act().fuse());
+        let mut f8 = Box::pin(act().fuse());
+        loop {
+            futures::select! {
+                _ = f1  => (),
+                _ = f2  => (),
+                _ = f3  => (),
+                _ = f4  => (),
+                _ = f5  => (),
+                _ = f6  => (),
+                _ = f7  => (),
+                _ = f8  => (),
+                complete => break,
+            }
+        }
+    });
+}


### PR DESCRIPTION
Adds tests for write ops and fix some bugs.

Bugs:

1. We were failing to move from prepared to submitted in the ring state machine, after submission succeeded. This bug was masked by the fact that we check for completion even if we havent submitted, but it could have led to spurious syscalls to io_uring_enter.
2. We were dropping the completion lock after we had deallocated it, causing a use after free.