### PR TITLE
(Trivial) Show crate use more clearly in example

### DIFF
--- a/examples/read-event.rs
+++ b/examples/read-event.rs
@@ -1,13 +1,13 @@
-use ringbahn::*;
+use ringbahn as rb;
 use std::fs::{metadata, File};
 use std::io;
 
 fn main() -> io::Result<()> {
-    let driver = drive::demo::driver();
+    let driver = rb::drive::demo::driver();
     let meta = metadata("props.txt")?;
     let mut file = File::open("props.txt")?;
-    let event = event::Read::new(&mut file, vec![0; meta.len() as usize]);
-    let submission = Submission::new(event, driver);
+    let event = rb::event::Read::new(&mut file, vec![0; meta.len() as usize]);
+    let submission = rb::Submission::new(event, driver);
     let content = futures::executor::block_on(async move {
         let (event, _, result) = submission.await;
         let bytes_read = result?;


### PR DESCRIPTION
This PR is a minor edit of PR #23 . Glob imports can add an element of cognitive overhead to understanding library usage. I chose `use ringbahn as rb;` so as to keep it concise and in the spirit of the original PR.