### PR TITLE
Fix Drive Pin guarantee soundness bug

### DIFF
--- a/examples/read-event.rs
+++ b/examples/read-event.rs
@@ -9,7 +9,7 @@ fn main() -> io::Result<()> {
     let event = event::Read::new(&mut file, vec![0; meta.len() as usize]);
     let submission = Submission::new(event, driver);
     let content = futures::executor::block_on(async move {
-        let (event, _, result) = submission.await;
+        let (event, result) = submission.await;
         let bytes_read = result?;
         let s = String::from_utf8_lossy(&event.buf[0..bytes_read]).to_string();
         io::Result::Ok(s)

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -14,7 +14,7 @@ use crate::drive::Completion as ExternalCompletion;
 pub struct Submission<E: Event, D> {
     state: State,
     event: ManuallyDrop<E>,
-    driver: ManuallyDrop<D>,
+    driver: D,
     completion: Completion,
 }
 
@@ -33,15 +33,20 @@ impl<E: Event, D: Drive> Submission<E, D> {
         Submission {
             state: State::Waiting,
             event: ManuallyDrop::new(event),
-            driver: ManuallyDrop::new(driver),
             completion: Completion::dangling(),
+            driver,
         }
+    }
+
+    /// Access the driver this submission is using
+    pub fn driver(&self) -> &D {
+        &self.driver
     }
 
     #[inline(always)]
     unsafe fn try_prepare(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<()> {
         let this = Pin::get_unchecked_mut(self);
-        let driver = Pin::new_unchecked(&mut *this.driver);
+        let driver = Pin::new_unchecked(&mut this.driver);
         let event = &mut *this.event;
         let state = &mut this.state;
         let completion = ready!(driver.poll_prepare(ctx, |sqe, ctx| {
@@ -62,14 +67,13 @@ impl<E: Event, D: Drive> Submission<E, D> {
     }
 
     #[inline(always)]
-    unsafe fn try_complete(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<(E, D, io::Result<usize>)> {
+    unsafe fn try_complete(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<(E, io::Result<usize>)> {
         let this = Pin::get_unchecked_mut(self);
         if let Some(result) = this.completion.check() {
             this.state = State::Complete;
             this.completion.deallocate();
             let event = ManuallyDrop::take(&mut this.event);
-            let driver = ManuallyDrop::take(&mut this.driver);
-            Poll::Ready((event, driver, result))
+            Poll::Ready((event, result))
         } else {
             this.completion.set_waker(ctx.waker().clone());
             Poll::Pending
@@ -80,7 +84,7 @@ impl<E: Event, D: Drive> Submission<E, D> {
     fn event_and_driver(self: Pin<&mut Self>) -> (&mut E, Pin<&mut D>) {
         unsafe {
             let this: &mut Submission<E, D> = Pin::get_unchecked_mut(self);
-            (&mut this.event, Pin::new_unchecked(&mut *this.driver))
+            (&mut this.event, Pin::new_unchecked(&mut this.driver))
         }
     }
 }
@@ -89,7 +93,7 @@ impl<E, D> Future for Submission<E, D> where
     E: Event,
     D: Drive,
 {
-    type Output = (E, D, io::Result<usize>);
+    type Output = (E, io::Result<usize>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         unsafe {
@@ -142,10 +146,6 @@ impl<E: Event, D> Drop for Submission<E, D> {
                 self.completion.cancel(Event::cancellation(&mut self.event));
             } else if self.state == State::Waiting {
                 ManuallyDrop::drop(&mut self.event);
-            }
-
-            if self.state != State::Complete {
-                ManuallyDrop::drop(&mut self.driver);
             }
         }
     }

--- a/tests/basic-read.rs
+++ b/tests/basic-read.rs
@@ -10,7 +10,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 fn read_file() {
     let mut file = File::open("props.txt").unwrap();
     let read: Read<'_, File> = Read::new(&mut file, vec![0; 4096]);
-    let (read, _, result) = futures::executor::block_on(Submission::new(read, demo::driver()));
+    let (read, result) = futures::executor::block_on(Submission::new(read, demo::driver()));
     assert!(result.is_ok());
     assert_eq!(&read.buf[0..ASSERT.len()], ASSERT);
 }

--- a/tests/basic-write.rs
+++ b/tests/basic-write.rs
@@ -11,7 +11,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 fn write_file() {
     let mut file = tempfile::tempfile().unwrap();
     let write: Write<'_, File> = Write::new(&mut file, Vec::from(ASSERT));
-    let (.., result) = futures::executor::block_on(Submission::new(write, demo::driver()));
+    let (_, result) = futures::executor::block_on(Submission::new(write, demo::driver()));
     assert_eq!(result.unwrap(), ASSERT.len());
 
     let mut buf = vec![];


### PR DESCRIPTION
The Drive trait intentionally pin projects, so that it can take
advantage of the pinning guarantee in its implementation. For example, a
valid Drive implementation could make use of an intrusive collection in
its definition.

However, I forgot about this and violated it by passing ownership of the
drive type out of Submission. This was done because when constructing,
for example, a File type, I need a driver for the file to run on.

Instead, file and tcpstream should use the same approach as tcplistener:
clone the drive handle used to set up the fd. This does not violate the
pin guarantees.