### PR TITLE
Add offset to read and write event.

### DIFF
--- a/examples/read-event.rs
+++ b/examples/read-event.rs
@@ -5,8 +5,8 @@ use std::io;
 fn main() -> io::Result<()> {
     let driver = drive::demo::driver();
     let meta = metadata("props.txt")?;
-    let mut file = File::open("props.txt")?;
-    let event = event::Read::new(&mut file, vec![0; meta.len() as usize]);
+    let file = File::open("props.txt")?;
+    let event = event::Read::new(&file, vec![0; meta.len() as usize], 0);
     let submission = Submission::new(event, driver);
     let content = futures::executor::block_on(async move {
         let (event, result) = submission.await;

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -6,19 +6,20 @@ use super::{Event, Cancellation};
 
 /// A basic read event.
 pub struct Read<'a, T> {
-    pub io: &'a mut T,
+    pub io: &'a T,
     pub buf: Vec<u8>,
+    pub offset: usize
 }
 
 impl<'a, T: AsRawFd + Unpin> Read<'a, T> {
-    pub fn new(io: &'a mut T, buf: Vec<u8>) -> Read<T> {
-        Read { io, buf }
+    pub fn new(io: &'a T, buf: Vec<u8>, offset: usize) -> Read<T> {
+        Read { io, buf, offset }
     }
 }
 
 impl<'a, T: AsRawFd + Unpin> Event for Read<'a, T> {
     unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
-        sqe.prep_read(self.io.as_raw_fd(), &mut self.buf[..], 0);
+        sqe.prep_read(self.io.as_raw_fd(), &mut self.buf[..], self.offset);
     }
 
     fn cancellation(this: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/event/write.rs
+++ b/src/event/write.rs
@@ -6,19 +6,20 @@ use super::{Event, Cancellation};
 
 /// A basic write event.
 pub struct Write<'a, T> {
-    pub io: &'a mut T,
+    pub io: &'a T,
     pub buf: Vec<u8>,
+    pub offset: usize
 }
 
 impl<'a, T: AsRawFd + Unpin> Write<'a, T> {
-    pub fn new(io: &'a mut T, buf: Vec<u8>) -> Write<T> {
-        Write { io, buf }
+    pub fn new(io: &'a T, buf: Vec<u8>, offset: usize) -> Write<T> {
+        Write { io, buf, offset }
     }
 }
 
 impl<'a, T: AsRawFd + Unpin> Event for Write<'a, T> {
     unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
-        sqe.prep_write(self.io.as_raw_fd(), self.buf.as_ref(), 0);
+        sqe.prep_write(self.io.as_raw_fd(), self.buf.as_ref(), self.offset);
     }
 
     fn cancellation(this: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/tests/basic-read.rs
+++ b/tests/basic-read.rs
@@ -8,8 +8,8 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 
 #[test]
 fn read_file() {
-    let mut file = File::open("props.txt").unwrap();
-    let read: Read<'_, File> = Read::new(&mut file, vec![0; 4096]);
+    let file = File::open("props.txt").unwrap();
+    let read: Read<'_, File> = Read::new(&file, vec![0; 4096], 0);
     let (read, result) = futures::executor::block_on(Submission::new(read, demo::driver()));
     assert!(result.is_ok());
     assert_eq!(&read.buf[0..ASSERT.len()], ASSERT);

--- a/tests/basic-write.rs
+++ b/tests/basic-write.rs
@@ -10,7 +10,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 #[test]
 fn write_file() {
     let mut file = tempfile::tempfile().unwrap();
-    let write: Write<'_, File> = Write::new(&mut file, Vec::from(ASSERT));
+    let write: Write<'_, File> = Write::new(&file, Vec::from(ASSERT), 0);
     let (_, result) = futures::executor::block_on(Submission::new(write, demo::driver()));
     assert_eq!(result.unwrap(), ASSERT.len());
 


### PR DESCRIPTION
Related to https://github.com/withoutboats/ringbahn/issues/24. Nothing fancy, but I want to add a note why I'm leaved references to AsRawFd instead of RawFd. What happens if the user drops / closes the file without waiting for the event to complete. On my PC tests just hang in this case.