### PR TITLE
New low-level API not based on iou.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ parking_lot = "0.10.2"
 once_cell = "1.3.1"
 libc = "0.2.71"
 uring-sys = "0.6.1"
-iou = "0.0.0-ringbahn.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/examples/read-event.rs
+++ b/examples/read-event.rs
@@ -10,7 +10,7 @@ fn main() -> io::Result<()> {
     let submission = Submission::new(event, driver);
     let content = futures::executor::block_on(async move {
         let (event, result) = submission.await;
-        let bytes_read = result?;
+        let bytes_read = result? as usize;
         let s = String::from_utf8_lossy(&event.buf[0..bytes_read]).to_string();
         io::Result::Ok(s)
     })?;

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -75,6 +75,7 @@ impl Completion {
         match &*state {
             Submitted(_)    => {
                 *state = Cancelled(callback);
+                drop(state);
             }
             Completed(_)    => {
                 drop(callback);

--- a/src/drive/demo.rs
+++ b/src/drive/demo.rs
@@ -92,7 +92,7 @@ fn complete(mut cq: CompletionQueue) {
         let mut ready = cq.ready() as usize + 1;
         SQ.release(ready);
 
-        super::complete(cqe.into());
+        cqe.complete();
         ready -= 1;
 
         while let Some(cqe) = cq.peek_for_cqe() {

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 
 use crate::completion;
 use crate::completion::complete;
-use crate::kernel::SQE;
+use crate::kernel::SubmissionSegment;
 
 
 /// A ccompletion which will be used to wake the task waiting on this event.
@@ -48,7 +48,8 @@ pub trait Drive {
     fn poll_prepare<'cx>(
         self: Pin<&mut Self>,
         ctx: &mut Context<'cx>,
-        prepare: impl FnOnce(&mut SQE, &mut Context<'cx>) -> Completion<'cx>,
+        count: u32,
+        prepare: impl FnOnce(SubmissionSegment<'_>, &mut Context<'cx>) -> Completion<'cx>,
     ) -> Poll<Completion<'cx>>;
 
     /// Submit all of the events on the submission queue.

--- a/src/event/close.rs
+++ b/src/event/close.rs
@@ -1,7 +1,7 @@
 use std::mem::ManuallyDrop;
 use std::os::unix::io::RawFd;
 
-use super::{Event, Cancellation};
+use super::{Event, SQE, Cancellation};
 
 pub struct Close {
     fd: RawFd,
@@ -14,8 +14,8 @@ impl Close {
 }
 
 impl Event for Close {
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
-        uring_sys::io_uring_prep_close(sqe.raw_mut(), self.fd)
+    unsafe fn prepare(&mut self, sqe: &mut SQE) {
+        sqe.prep_close(self.fd)
     }
 
     unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/event/close.rs
+++ b/src/event/close.rs
@@ -1,7 +1,7 @@
 use std::mem::ManuallyDrop;
 use std::os::unix::io::RawFd;
 
-use super::{Event, SQE, Cancellation};
+use super::{Event, SubmissionSegment, Cancellation};
 
 pub struct Close {
     fd: RawFd,
@@ -14,8 +14,10 @@ impl Close {
 }
 
 impl Event for Close {
-    unsafe fn prepare(&mut self, sqe: &mut SQE) {
-        sqe.prep_close(self.fd)
+    fn sqes_needed(&self) -> u32 { 1 }
+
+    unsafe fn prepare(&mut self, sqs: &mut SubmissionSegment<'_>) {
+        sqs.singular().prep_close(self.fd)
     }
 
     unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/event/connect.rs
+++ b/src/event/connect.rs
@@ -3,7 +3,7 @@ use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
 use std::net::SocketAddr;
 
-use super::{Event, SQE, Cancellation};
+use super::{Event, SubmissionSegment, Cancellation};
 
 pub struct Connect {
     pub fd: RawFd,
@@ -19,8 +19,10 @@ impl Connect {
 }
 
 impl Event for Connect {
-    unsafe fn prepare(&mut self, sqe: &mut SQE) {
-        sqe.prep_connect(self.fd, &mut *self.addr, self.addrlen);
+    fn sqes_needed(&self) -> u32 { 1 }
+
+    unsafe fn prepare(&mut self, sqs: &mut SubmissionSegment<'_>) {
+        sqs.singular().prep_connect(self.fd, &mut *self.addr, self.addrlen);
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -9,7 +9,7 @@ mod write;
 use std::mem::ManuallyDrop;
 
 use crate::cancellation::Cancellation;
-use crate::kernel::SQE;
+use crate::kernel::SubmissionSegment;
 
 pub use connect::Connect;
 pub use close::Close;
@@ -29,6 +29,8 @@ pub use write::Write;
 /// implementer has upheld. The implementer is not allowed to add any additional invariants that
 /// the caller must uphold that are not required by the trait.
 pub trait Event {
+    fn sqes_needed(&self) -> u32;
+
     /// Prepare an event to be submitted using the SQE argument.
     ///
     /// ## Safety
@@ -48,7 +50,7 @@ pub trait Event {
     /// In essence implementing prepare, users can write code ass if any heap addresses passed to
     /// the  kernel have passed ownership of that data to the kernel for the time that the event is
     /// completed.
-    unsafe fn prepare(&mut self, sqe: &mut SQE);
+    unsafe fn prepare(&mut self, sqs: &mut SubmissionSegment<'_>);
 
     /// Return the cancellation callback for this event.
     ///

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -9,6 +9,7 @@ mod write;
 use std::mem::ManuallyDrop;
 
 use crate::cancellation::Cancellation;
+use crate::kernel::SQE;
 
 pub use connect::Connect;
 pub use close::Close;
@@ -47,7 +48,7 @@ pub trait Event {
     /// In essence implementing prepare, users can write code ass if any heap addresses passed to
     /// the  kernel have passed ownership of that data to the kernel for the time that the event is
     /// completed.
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>);
+    unsafe fn prepare(&mut self, sqe: &mut SQE);
 
     /// Return the cancellation callback for this event.
     ///

--- a/src/event/openat.rs
+++ b/src/event/openat.rs
@@ -4,7 +4,7 @@ use std::os::unix::io::RawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
-use super::{Event, Cancellation};
+use super::{Event, SQE, Cancellation};
 
 pub struct OpenAt {
     path: CString,
@@ -21,9 +21,8 @@ impl OpenAt {
 }
 
 impl Event for OpenAt {
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
-        let path = self.path.as_ptr();
-        uring_sys::io_uring_prep_openat(sqe.raw_mut(), self.dfd, path, self.flags, self.mode);
+    unsafe fn prepare(&mut self, sqe: &mut SQE) {
+        sqe.prep_openat(self.dfd, self.path.as_ptr(), self.flags, self.mode)
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/event/openat.rs
+++ b/src/event/openat.rs
@@ -4,7 +4,7 @@ use std::os::unix::io::RawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
-use super::{Event, SQE, Cancellation};
+use super::{Event, SubmissionSegment, Cancellation};
 
 pub struct OpenAt {
     path: CString,
@@ -21,8 +21,10 @@ impl OpenAt {
 }
 
 impl Event for OpenAt {
-    unsafe fn prepare(&mut self, sqe: &mut SQE) {
-        sqe.prep_openat(self.dfd, self.path.as_ptr(), self.flags, self.mode)
+    fn sqes_needed(&self) -> u32 { 1 }
+
+    unsafe fn prepare(&mut self, sqs: &mut SubmissionSegment<'_>) {
+        sqs.singular().prep_openat(self.dfd, self.path.as_ptr(), self.flags, self.mode)
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -2,23 +2,23 @@ use std::os::unix::io::AsRawFd;
 use std::mem::ManuallyDrop;
 use std::marker::Unpin;
 
-use super::{Event, Cancellation};
+use super::{Event, SQE, Cancellation};
 
 /// A basic read event.
 pub struct Read<'a, T> {
     pub io: &'a T,
     pub buf: Vec<u8>,
-    pub offset: usize
+    pub offset: u64
 }
 
 impl<'a, T: AsRawFd + Unpin> Read<'a, T> {
-    pub fn new(io: &'a T, buf: Vec<u8>, offset: usize) -> Read<T> {
+    pub fn new(io: &'a T, buf: Vec<u8>, offset: u64) -> Read<T> {
         Read { io, buf, offset }
     }
 }
 
 impl<'a, T: AsRawFd + Unpin> Event for Read<'a, T> {
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+    unsafe fn prepare(&mut self, sqe: &mut SQE) {
         sqe.prep_read(self.io.as_raw_fd(), &mut self.buf[..], self.offset);
     }
 

--- a/src/event/write.rs
+++ b/src/event/write.rs
@@ -2,23 +2,23 @@ use std::os::unix::io::AsRawFd;
 use std::mem::ManuallyDrop;
 use std::marker::Unpin;
 
-use super::{Event, Cancellation};
+use super::{Event, SQE, Cancellation};
 
 /// A basic write event.
 pub struct Write<'a, T> {
     pub io: &'a T,
     pub buf: Vec<u8>,
-    pub offset: usize
+    pub offset: u64
 }
 
 impl<'a, T: AsRawFd + Unpin> Write<'a, T> {
-    pub fn new(io: &'a T, buf: Vec<u8>, offset: usize) -> Write<T> {
+    pub fn new(io: &'a T, buf: Vec<u8>, offset: u64) -> Write<T> {
         Write { io, buf, offset }
     }
 }
 
 impl<'a, T: AsRawFd + Unpin> Event for Write<'a, T> {
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+    unsafe fn prepare(&mut self, sqe: &mut SQE) {
         sqe.prep_write(self.io.as_raw_fd(), self.buf.as_ref(), self.offset);
     }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -25,7 +25,7 @@ pub struct File<D: Drive = DemoDriver<'static>> {
     fd: RawFd,
     active: Op,
     buf: Buffer,
-    pos: usize,
+    pos: u64,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -106,7 +106,7 @@ impl<D: Drive> File<D> {
         self.ring.cancel(self.buf.cancellation());
     }
 
-    fn poll_file_size(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+    fn poll_file_size(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<u64>> {
         static EMPTY: libc::c_char = 0;
 
         self.as_mut().guard_op(Op::Statx);
@@ -116,16 +116,13 @@ impl<D: Drive> File<D> {
         let flags = libc::AT_EMPTY_PATH;
         let mask = libc::STATX_SIZE;
         unsafe {
-            ready!(ring.poll(ctx, true, |sqe| {
-                uring_sys::io_uring_prep_statx(sqe.raw_mut(), fd, &EMPTY, flags, mask, statx);
-            }))?;
-
-            Poll::Ready(Ok((*statx).stx_size as usize))
+            ready!(ring.poll(ctx, true, |sqe| sqe.prep_statx(fd, &EMPTY, flags, mask, statx)))?;
+            Poll::Ready(Ok((*statx).stx_size))
         }
     }
 
     #[inline(always)]
-    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Buffer, &mut usize) {
+    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Buffer, &mut u64) {
         unsafe {
             let this = Pin::get_unchecked_mut(self);
             (Pin::new_unchecked(&mut this.ring), &mut this.buf, &mut this.pos)
@@ -143,7 +140,7 @@ impl<D: Drive> File<D> {
     }
 
     #[inline(always)]
-    fn pos(self: Pin<&mut Self>) -> Pin<&mut usize> {
+    fn pos(self: Pin<&mut Self>) -> Pin<&mut u64> {
         unsafe { Pin::map_unchecked_mut(self, |this| &mut this.pos) }
     }
 }
@@ -166,7 +163,7 @@ impl<D: Drive> AsyncBufRead for File<D> {
         let (ring, buf, pos) = self.split();
         buf.fill_buf(|buf| {
             let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_read(fd, buf, *pos) }))?;
-            *pos += n;
+            *pos += n as u64;
             Poll::Ready(Ok(n as u32))
         })
     }
@@ -185,9 +182,9 @@ impl<D: Drive> AsyncWrite for File<D> {
             Poll::Ready(Ok(io::Write::write(&mut buf, slice)? as u32))
         }))?;
         let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_write(fd, data, *pos) }))?;
-        *pos += n;
+        *pos += n as u64;
         buf.clear();
-        Poll::Ready(Ok(n))
+        Poll::Ready(Ok(n as usize))
     }
 
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -198,9 +195,7 @@ impl<D: Drive> AsyncWrite for File<D> {
     fn poll_close(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.as_mut().guard_op(Op::Close);
         let fd = self.fd;
-        ready!(self.ring().poll(ctx, true, |sqe| unsafe {
-            uring_sys::io_uring_prep_close(sqe.raw_mut(), fd)
-        }))?;
+        ready!(self.ring().poll(ctx, true, |sqe| sqe.prep_close(fd)))?;
         Poll::Ready(Ok(()))
     }
 }
@@ -210,13 +205,13 @@ impl<D: Drive> AsyncSeek for File<D> {
         -> Poll<io::Result<u64>>
     {
         match pos {
-            io::SeekFrom::Start(n)      => *self.as_mut().pos() = n as usize,
+            io::SeekFrom::Start(n)      => *self.as_mut().pos() = n as u64,
             io::SeekFrom::Current(n)    => {
-                *self.as_mut().pos() += if n < 0 { n.abs() } else { n } as usize;
+                *self.as_mut().pos() += if n < 0 { n.abs() } else { n } as u64;
             }
             io::SeekFrom::End(n)        => {
                 let end = ready!(self.as_mut().poll_file_size(ctx))?;
-                *self.as_mut().pos() = end + if n < 0 { n.abs() } else { n} as usize;
+                *self.as_mut().pos() = end + if n < 0 { n.abs() } else { n} as u64;
             }
         }
         Poll::Ready(Ok(self.pos as u64))

--- a/src/kernel/completion_queue.rs
+++ b/src/kernel/completion_queue.rs
@@ -1,0 +1,60 @@
+use std::io;
+use std::mem::MaybeUninit;
+use std::ptr;
+use std::sync::Arc;
+
+use super::{IoUring, CQE};
+
+pub struct CompletionQueue {
+    ring: Arc<IoUring>,
+}
+
+impl CompletionQueue {
+    pub(crate) fn new(ring: Arc<IoUring>) -> CompletionQueue {
+        CompletionQueue { ring }
+    }
+
+    pub fn wait_for_cqe(&mut self) -> io::Result<CQE> {
+        unsafe {
+            let mut cqe = MaybeUninit::uninit();
+
+            match uring_sys::io_uring_wait_cqes(
+                self.ring.ring(),
+                cqe.as_mut_ptr(),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ) {
+                n if n >= 0 => {
+                    let cqe_slot = cqe.assume_init();
+                    let cqe = CQE::from_raw(ptr::read(cqe_slot));
+                    uring_sys::io_uring_cqe_seen(self.ring.ring(), cqe_slot);
+                    Ok(cqe)
+                }
+                n           => Err(io::Error::from_raw_os_error(-n)),
+            }
+        }
+    }
+
+    pub fn peek_for_cqe(&mut self) -> Option<CQE> {
+        unsafe {
+            let mut cqe = MaybeUninit::uninit();
+            let count = uring_sys::io_uring_peek_batch_cqe(self.ring.ring(), cqe.as_mut_ptr(), 1);
+            if count > 0 {
+                let cqe_slot = cqe.assume_init();
+                let cqe = CQE::from_raw(ptr::read(cqe_slot));
+                uring_sys::io_uring_cqe_seen(self.ring.ring(), cqe_slot);
+                Some(cqe)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn ready(&self) -> u32 {
+        unsafe { uring_sys::io_uring_cq_ready(self.ring.ring()) }
+    }
+}
+
+unsafe impl Send for CompletionQueue { }
+unsafe impl Sync for CompletionQueue { }

--- a/src/kernel/cqe.rs
+++ b/src/kernel/cqe.rs
@@ -1,0 +1,32 @@
+use std::io;
+
+pub struct CQE {
+    user_data: u64,
+    res: i32,
+    flags: u32,
+}
+
+impl CQE {
+    pub(crate) fn from_raw(cqe: uring_sys::io_uring_cqe) -> CQE {
+        CQE { user_data: cqe.user_data, res: cqe.res, flags: cqe.flags }
+    }
+
+    pub fn complete(self) {
+        crate::completion::complete(self)
+    }
+
+    pub fn result(&self) -> io::Result<u32> {
+        match self.res {
+            n if n >= 0     => Ok(n as u32),
+            err             => Err(io::Error::from_raw_os_error(err)),
+        }
+    }
+
+    pub fn flags(&self) -> u32 {
+        self.flags
+    }
+
+    pub fn user_data(&self) -> u64 {
+        self.user_data
+    }
+}

--- a/src/kernel/cqe.rs
+++ b/src/kernel/cqe.rs
@@ -7,7 +7,7 @@ pub struct CQE {
 }
 
 impl CQE {
-    pub(crate) fn from_raw(cqe: uring_sys::io_uring_cqe) -> CQE {
+    pub(super) fn from_raw(cqe: uring_sys::io_uring_cqe) -> CQE {
         CQE { user_data: cqe.user_data, res: cqe.res, flags: cqe.flags }
     }
 

--- a/src/kernel/hard_linked.rs
+++ b/src/kernel/hard_linked.rs
@@ -1,0 +1,53 @@
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+use super::{SubmissionSegment, SQE};
+
+pub struct HardLinked<'a, 'b> {
+    segment: *mut SubmissionSegment<'b>,
+    marker: PhantomData<&'a mut SubmissionSegment<'b>>,
+}
+
+impl<'a, 'b> HardLinked<'a, 'b> {
+    pub(super) fn new(segment: &'a mut SubmissionSegment<'b>) -> HardLinked<'a, 'b> {
+        HardLinked { segment, marker: PhantomData }
+    }
+}
+
+impl<'a, 'b> Iterator for HardLinked<'a, 'b> {
+    type Item = HardLinkedSQE<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            let is_final = (&*self.segment).remaining() > 1;
+            let sqe = (&mut *self.segment).consume()?;
+            Some(HardLinkedSQE { sqe, is_final })
+        }
+    }
+}
+
+pub struct HardLinkedSQE<'a> {
+    sqe: &'a mut SQE,
+    is_final: bool,
+}
+
+impl<'a> Deref for HardLinkedSQE<'a> {
+    type Target = SQE;
+    fn deref(&self) -> &SQE {
+        self.sqe
+    }
+}
+
+impl<'a> DerefMut for HardLinkedSQE<'a> {
+    fn deref_mut(&mut self) -> &mut SQE {
+        self.sqe
+    }
+}
+
+impl Drop for HardLinkedSQE<'_> {
+    fn drop(&mut self) {
+        if !self.is_final {
+            self.sqe.set_flag(uring_sys::IOSQE_IO_HARDLINK);
+        }
+    }
+}

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,0 +1,11 @@
+mod cqe;
+mod sqe;
+mod completion_queue;
+mod submission_queue;
+mod ring;
+
+pub use sqe::SQE;
+pub use cqe::CQE;
+pub use completion_queue::CompletionQueue;
+pub use submission_queue::SubmissionQueue;
+pub use ring::IoUring;

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -7,5 +7,5 @@ mod ring;
 pub use sqe::SQE;
 pub use cqe::CQE;
 pub use completion_queue::CompletionQueue;
-pub use submission_queue::SubmissionQueue;
+pub use submission_queue::{SubmissionQueue, SubmissionSegment};
 pub use ring::IoUring;

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -14,4 +14,4 @@ pub use completion_queue::CompletionQueue;
 pub use submission_queue::{SubmissionQueue, SubmissionSegment};
 pub use ring::IoUring;
 
-pub use hard_linked::HardLinked;
+pub use hard_linked::{HardLinked, HardLinkedSQE};

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,11 +1,17 @@
 mod cqe;
 mod sqe;
+
 mod completion_queue;
 mod submission_queue;
 mod ring;
 
+mod hard_linked;
+
 pub use sqe::SQE;
 pub use cqe::CQE;
+
 pub use completion_queue::CompletionQueue;
 pub use submission_queue::{SubmissionQueue, SubmissionSegment};
 pub use ring::IoUring;
+
+pub use hard_linked::HardLinked;

--- a/src/kernel/ring.rs
+++ b/src/kernel/ring.rs
@@ -1,0 +1,40 @@
+use std::io;
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use super::{SubmissionQueue, CompletionQueue};
+
+pub struct IoUring {
+    ring: uring_sys::io_uring,
+}
+
+impl IoUring {
+    pub fn new(entries: u32) -> io::Result<IoUring> {
+        unsafe {
+            let mut ring = MaybeUninit::uninit();
+            match uring_sys::io_uring_queue_init(entries as _, ring.as_mut_ptr(), 0) {
+                n if n >= 0 => Ok(IoUring { ring: ring.assume_init() }),
+                n           => Err(io::Error::from_raw_os_error(-n)),
+            }
+        }
+    }
+
+    pub fn queues(self) -> (SubmissionQueue, CompletionQueue) {
+        let ring = Arc::new(self);
+        (SubmissionQueue::new(ring.clone()), CompletionQueue::new(ring))
+    }
+
+    pub(super) fn ring(&self) -> *mut uring_sys::io_uring {
+        NonNull::from(&self.ring).as_ptr()
+    }
+}
+
+unsafe impl Send for IoUring { }
+unsafe impl Sync for IoUring { }
+
+impl Drop for IoUring {
+    fn drop(&mut self) {
+        unsafe { uring_sys::io_uring_queue_exit(&mut self.ring) };
+    }
+}

--- a/src/kernel/sqe.rs
+++ b/src/kernel/sqe.rs
@@ -1,0 +1,60 @@
+use std::os::unix::io::RawFd;
+use std::ptr::NonNull;
+
+use crate::completion::Completion;
+
+#[repr(transparent)]
+pub struct SQE {
+    inner: uring_sys::io_uring_sqe,
+}
+
+impl SQE {
+    pub(crate) fn from_raw(sqe: &mut uring_sys::io_uring_sqe) -> &mut SQE {
+        sqe.user_data = 0;
+        unsafe { &mut *NonNull::from(sqe).cast().as_ptr() }
+    }
+
+    pub(crate) fn set_completion(&mut self, completion: &Completion) {
+        self.inner.user_data = completion.addr();
+    }
+
+    pub(crate) fn unset_completion(&mut self) {
+        self.inner.user_data = 0;
+    }
+
+    pub fn prep_nop(&mut self) {
+        unsafe { uring_sys::io_uring_prep_nop(&mut self.inner) };
+    }
+
+    pub unsafe fn prep_write(&mut self, fd: RawFd, buf: &[u8], off: u64) {
+        let len = buf.len();
+        let addr = buf.as_ptr();
+        uring_sys::io_uring_prep_write(&mut self.inner, fd, addr as _, len as _, off as _);
+    }
+
+    pub unsafe fn prep_read(&mut self, fd: RawFd, buf: &mut [u8], off: u64) {
+        let len = buf.len();
+        let addr = buf.as_mut_ptr();
+        uring_sys::io_uring_prep_read(&mut self.inner, fd, addr as _, len as _, off as _);
+    }
+
+    pub unsafe fn prep_openat(&mut self, dfd: RawFd, path: *const libc::c_char, flags: i32, mode: u32) {
+        uring_sys::io_uring_prep_openat(&mut self.inner, dfd, path, flags, mode);
+    }
+
+    pub unsafe fn prep_connect(&mut self, fd: RawFd, addr: *mut libc::sockaddr_storage, len: libc::socklen_t) {
+        uring_sys::io_uring_prep_connect(&mut self.inner, fd, addr as *mut libc::sockaddr, len)
+    }
+
+    pub unsafe fn prep_accept(&mut self, fd: RawFd, addr: *mut libc::sockaddr_storage, len: *mut libc::socklen_t, flags: i32) {
+        uring_sys::io_uring_prep_accept(&mut self.inner, fd, addr as *mut libc::sockaddr, len, flags)
+    }
+
+    pub unsafe fn prep_statx(&mut self, fd: RawFd, path: *const libc::c_char, flags: i32, mask: u32, statx: *mut libc::statx) {
+        uring_sys::io_uring_prep_statx(&mut self.inner, fd, path, flags, mask, statx);
+    }
+
+    pub fn prep_close(&mut self, fd: RawFd) {
+        unsafe { uring_sys::io_uring_prep_close(&mut self.inner, fd); }
+    }
+}

--- a/src/kernel/sqe.rs
+++ b/src/kernel/sqe.rs
@@ -9,7 +9,7 @@ pub struct SQE {
 }
 
 impl SQE {
-    pub(crate) fn from_raw(sqe: &mut uring_sys::io_uring_sqe) -> &mut SQE {
+    pub(super) fn from_raw(sqe: &mut uring_sys::io_uring_sqe) -> &mut SQE {
         sqe.user_data = 0;
         unsafe { &mut *NonNull::from(sqe).cast().as_ptr() }
     }

--- a/src/kernel/sqe.rs
+++ b/src/kernel/sqe.rs
@@ -54,6 +54,10 @@ impl SQE {
         unsafe { uring_sys::io_uring_prep_close(&mut self.inner, fd); }
     }
 
+    pub fn prep_cancel(&mut self, user_data: u64, flags: i32) {
+        unsafe { uring_sys::io_uring_prep_cancel(&mut self.inner, user_data as _, flags) }
+    }
+
     pub fn set_flag(&mut self, flag: u8) {
         self.inner.flags &= flag;
     }

--- a/src/kernel/sqe.rs
+++ b/src/kernel/sqe.rs
@@ -18,10 +18,6 @@ impl SQE {
         self.inner.user_data = completion.addr();
     }
 
-    pub(crate) fn unset_completion(&mut self) {
-        self.inner.user_data = 0;
-    }
-
     pub fn prep_nop(&mut self) {
         unsafe { uring_sys::io_uring_prep_nop(&mut self.inner) };
     }
@@ -56,5 +52,13 @@ impl SQE {
 
     pub fn prep_close(&mut self, fd: RawFd) {
         unsafe { uring_sys::io_uring_prep_close(&mut self.inner, fd); }
+    }
+
+    pub fn set_flag(&mut self, flag: u8) {
+        self.inner.flags &= flag;
+    }
+
+    pub fn unset_flag(&mut self, flag: u8) {
+        self.inner.flags &= !flag;
     }
 }

--- a/src/kernel/submission_queue.rs
+++ b/src/kernel/submission_queue.rs
@@ -1,0 +1,100 @@
+use std::io;
+use std::sync::Arc;
+
+use super::{IoUring, SQE};
+
+pub struct SubmissionQueue {
+    ring: Arc<IoUring>,
+}
+
+impl SubmissionQueue {
+    pub(crate) fn new(ring: Arc<IoUring>) -> SubmissionQueue {
+        SubmissionQueue { ring }
+    }
+
+    pub fn prepare(&mut self, n: u32) -> Option<SubmissionSegment<'_>> {
+        unsafe {
+            let ring = self.ring.ring();
+            let sq = &mut (*ring).sq;
+            if ((*ring).flags & uring_sys::IORING_SETUP_SQPOLL) == 0 {
+                use std::sync::atomic::*;
+                fence(Ordering::Acquire);
+            };
+            let head = *sq.khead;
+
+            let next = sq.sqe_tail + n;
+            if next - head <= *sq.kring_entries {
+                let offset = sq.sqe_tail & *sq.kring_mask;
+                sq.sqe_tail = next;
+                let head = Some(&mut *sq.sqes.offset(offset as isize));
+                Some(SubmissionSegment { head, remaining: n })
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn submit(&mut self) -> io::Result<u32> {
+        match unsafe { uring_sys::io_uring_submit(self.ring.ring()) } {
+            n if n >= 0 => {
+                println!("submitted {}", n);
+                Ok(n as u32)
+            }
+            n           => Err(io::Error::from_raw_os_error(-n)),
+        }
+    }
+}
+
+unsafe impl Send for SubmissionQueue { }
+unsafe impl Sync for SubmissionQueue { }
+
+pub struct SubmissionSegment<'a> {
+    head: Option<&'a mut uring_sys::io_uring_sqe>,
+    remaining: u32,
+}
+
+impl<'a> SubmissionSegment<'a> {
+    pub fn singular(mut self) -> &'a mut SQE {
+        while self.remaining > 1 {
+            self.consume().unwrap().prep_nop();
+        }
+
+        self.consume().unwrap()
+    }
+
+    pub fn hard_linked(self) -> HardLinked<'a> {
+        HardLinked { segment: self }
+    }
+
+    fn consume(&mut self) -> Option<&'a mut SQE> {
+        let next = self.head.take()?;
+
+        self.remaining -= 1;
+        if self.remaining > 0 {
+            unsafe {
+                let sqe = (next as *mut uring_sys::io_uring_sqe).offset(1);
+                self.head = Some(&mut *sqe);
+            }
+        }
+
+        Some(SQE::from_raw(next))
+    }
+}
+
+pub struct HardLinked<'a> {
+    segment: SubmissionSegment<'a>,
+}
+
+impl<'a> Iterator for HardLinked<'a> {
+    type Item = &'a mut SQE;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO after the user is done with it, if there are remaining SQEs, I want to set
+        // IORING_SQE_HARDLINK
+        //
+        // Make sure that all of the unused are filled with noops
+        //
+        // Make it so the completion is only set on the final SQE somehow
+        self.segment.consume()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,5 @@ pub use drive::Drive;
 pub use event::Event;
 #[doc(inline)]
 pub use fs::File;
+
+pub mod kernel;

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -131,7 +131,7 @@ impl<D: Drive> AsyncBufRead for TcpStream<D> {
         let fd = self.fd;
         let (ring, buf) = self.split();
         buf.fill_buf(|buf| {
-            let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_read(fd, buf, 0) }))?;
+            let n = ready!(ring.poll(ctx, true, 1, |sqs| unsafe { sqs.singular().prep_read(fd, buf, 0) }))?;
             Poll::Ready(Ok(n as u32))
         })
     }
@@ -149,7 +149,7 @@ impl<D: Drive> AsyncWrite for TcpStream<D> {
         let data = ready!(buf.fill_buf(|mut buf| {
             Poll::Ready(Ok(io::Write::write(&mut buf, slice)? as u32))
         }))?;
-        let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_write(fd, data, 0) }))?;
+        let n = ready!(ring.poll(ctx, true, 1, |sqs| unsafe { sqs.singular().prep_write(fd, data, 0) }))?;
         buf.clear();
         Poll::Ready(Ok(n as usize))
     }
@@ -162,7 +162,7 @@ impl<D: Drive> AsyncWrite for TcpStream<D> {
     fn poll_close(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.as_mut().guard_op(Op::Close);
         let fd = self.fd;
-        ready!(self.ring().poll(ctx, true, |sqe| sqe.prep_close(fd)))?;
+        ready!(self.ring().poll(ctx, true, 1, |sqs| sqs.singular().prep_close(fd)))?;
         Poll::Ready(Ok(()))
     }
 }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -25,18 +26,17 @@ use State::*;
 /// implementing drop to call cancel properly.
 pub struct Ring<D: Drive> {
     state: State,
-    completion: Option<Completion>,
     driver: D,
 }
 
-
-#[derive(Debug, Eq, PartialEq)]
 enum State {
-    Inert = 0,
-    Prepared,
-    Submitted,
+    Inert,
+    Prepared(Completion),
+    Submitted(Completion),
+    Cancelled(u64),
     Lost,
 }
+
 
 impl<D: Default + Drive> Default for Ring<D> {
     fn default() -> Ring<D> {
@@ -56,7 +56,6 @@ impl<D: Drive> Ring<D> {
     pub fn new(driver: D) -> Ring<D> {
         Ring {
             state: Inert,
-            completion: None,
             driver
         }
     }
@@ -80,12 +79,12 @@ impl<D: Drive> Ring<D> {
         prepare: impl FnOnce(&mut SubmissionSegment<'_>),
     ) -> Poll<io::Result<u32>> {
         match self.state {
-            Inert       => {
+            Inert | Cancelled(_) => {
                 ready!(self.as_mut().poll_prepare(ctx, count, prepare));
                 ready!(self.as_mut().poll_submit(ctx, is_eager));
                 Poll::Pending
             }
-            Prepared    => {
+            Prepared(_)             => {
                 match self.as_mut().poll_complete(ctx) {
                     ready @ Poll::Ready(..) => ready,
                     Poll::Pending           => {
@@ -94,8 +93,8 @@ impl<D: Drive> Ring<D> {
                     }
                 }
             }
-            Submitted   => self.poll_complete(ctx),
-            Lost        => panic!("Ring in a bad state; driver is faulty"),
+            Submitted(_)            => self.poll_complete(ctx),
+            Lost                    => panic!("Ring in a bad state; driver is faulty"),
         }
     }
 
@@ -106,38 +105,71 @@ impl<D: Drive> Ring<D> {
         count: u32,
         prepare: impl FnOnce(&mut SubmissionSegment),
     ) -> Poll<()> {
-        let (driver, state, completion_slot) = self.split();
-        let completion = ready!(driver.poll_prepare(ctx, count, |mut sqs, ctx| {
-            *state = Lost;
-            prepare(&mut sqs);
-            sqs.finish(ctx)
-        }));
-        *state = Prepared;
-        *completion_slot = Some(completion.real);
+        let (driver, state) = self.split();
+        let completion = match *state {
+            Cancelled(prev) => {
+                ready!(driver.poll_prepare(ctx, count + 1, |mut sqs, ctx| {
+                    *state = Lost;
+                    sqs.hard_linked().next().unwrap().prep_cancel(prev, 0);
+                    prepare(&mut sqs);
+                    sqs.finish(ctx)
+                }))
+            }
+            Inert           => {
+                ready!(driver.poll_prepare(ctx, count, |mut sqs, ctx| {
+                    *state = Lost;
+                    prepare(&mut sqs);
+                    sqs.finish(ctx)
+                }))
+            }
+            _               => unreachable!(),
+        };
+        *state = Prepared(completion.real);
         Poll::Ready(())
     }
 
     #[inline(always)]
     fn poll_submit(self: Pin<&mut Self>, ctx: &mut Context<'_>, is_eager: bool) -> Poll<()> {
-        let (driver, state, _) = self.split();
+        let (driver, state) = self.split();
         // TODO figure out how to handle this result
         let _ = ready!(driver.poll_submit(ctx, is_eager));
-        *state = Submitted;
-        Poll::Ready(())
+        if let Prepared(completion) | Submitted(completion) = mem::replace(state, Lost) {
+            *state = Submitted(completion);
+            Poll::Ready(())
+        } else {
+            unreachable!()
+        }
     }
 
     #[inline(always)]
     fn poll_complete(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<u32>> {
-        let (_, state, completion_slot) = self.split();
-        match completion_slot.take().unwrap().check(ctx.waker()) {
-            Ok(result)      => {
-                *state = Inert;
-                Poll::Ready(result)
+        let (_, state) = self.split();
+        match mem::replace(state, Lost) {
+            Prepared(completion)    => {
+                match completion.check(ctx.waker()) {
+                    Ok(result)      => {
+                        *state = Inert;
+                        Poll::Ready(result)
+                    }
+                    Err(completion) => {
+                        *state = Prepared(completion);
+                        Poll::Pending
+                    }
+                }
             }
-            Err(completion) => {
-                *completion_slot = Some(completion);
-                Poll::Pending
+            Submitted(completion)   => {
+                match completion.check(ctx.waker()) {
+                    Ok(result)      => {
+                        *state = Inert;
+                        Poll::Ready(result)
+                    }
+                    Err(completion) => {
+                        *state = Submitted(completion);
+                        Poll::Pending
+                    }
+                }
             }
+            _                       => unreachable!(),
         }
     }
 
@@ -147,8 +179,14 @@ impl<D: Drive> Ring<D> {
     /// clean up the resources of the running event.
     #[inline]
     pub fn cancel(&mut self, cancellation: Cancellation) {
-        if let Some(completion) = self.completion.take() {
-            completion.cancel(cancellation);
+        match mem::replace(&mut self.state, Lost) {
+            Prepared(completion) | Submitted(completion) => {
+                self.state = Cancelled(completion.addr());
+                completion.cancel(cancellation);
+            }
+            state                                       => {
+                self.state = state;
+            }
         }
     }
 
@@ -159,10 +197,10 @@ impl<D: Drive> Ring<D> {
         unsafe { Pin::get_unchecked_mut(self).cancel(cancellation) }
     }
 
-    fn split(self: Pin<&mut Self>) -> (Pin<&mut D>, &mut State, &mut Option<Completion>) {
+    fn split(self: Pin<&mut Self>) -> (Pin<&mut D>, &mut State) {
         unsafe {
             let this = Pin::get_unchecked_mut(self);
-            (Pin::new_unchecked(&mut this.driver), &mut this.state, &mut this.completion)
+            (Pin::new_unchecked(&mut this.driver), &mut this.state)
         }
     }
 }

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -40,7 +40,7 @@ impl<E, D> Future for Submission<E, D> where
     E: Event,
     D: Drive,
 {
-    type Output = (E, io::Result<usize>);
+    type Output = (E, io::Result<u32>);
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let (ring, event) = self.split();

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -46,7 +46,9 @@ impl<E, D> Future for Submission<E, D> where
         let (ring, event) = self.split();
 
         let result = if let Some(event) = event {
-            ready!(ring.poll(ctx, event.is_eager(), |sqe| unsafe { event.prepare(sqe) }))
+            let is_eager = event.is_eager();
+            let count = event.sqes_needed();
+            ready!(ring.poll(ctx, is_eager, count, |sqs| unsafe { event.prepare(sqs) }))
         } else {
             panic!("polled Submission after completion")
         };

--- a/tests/basic-write.rs
+++ b/tests/basic-write.rs
@@ -12,7 +12,7 @@ fn write_file() {
     let mut file = tempfile::tempfile().unwrap();
     let write: Write<'_, File> = Write::new(&file, Vec::from(ASSERT), 0);
     let (_, result) = futures::executor::block_on(Submission::new(write, demo::driver()));
-    assert_eq!(result.unwrap(), ASSERT.len());
+    assert_eq!(result.unwrap() as usize, ASSERT.len());
 
     let mut buf = vec![];
     assert_eq!(file.read_to_end(&mut buf).unwrap(), ASSERT.len());


### PR DESCRIPTION
This makes setting the user_data field private to ringbahn, so it is safe to complete a CQE assuming it contains a Completion. With some other changes around ring ownership, it makes the demo driver 100% safe code.

The full iou API has not yet been implemented, just enough to implement the demo driver.

This also changes the process of getting SQEs from the SQ, to allow multiple SQEs to be requested to prepare a single event. The only multi-SQE API is the `hard_linked` API, which allows multiple events to be linked together with `IORING_SQE_HARDLINK`. The result of all but hte final event will be ignored; the completion will only awaken on the final event.

The `Ring` type will track if interest in an event has been cancelled, and if it has it will hard link a cancellation of that event before any subsequent events. This will hopefully make the events serialize properly, so that the previous event will complete or cancel before the subsequent event.

Closes #33

Closes #22