### PR TITLE
implement `readv`, `writev` Events

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -6,6 +6,7 @@ mod read;
 mod readv;
 mod openat;
 mod write;
+mod writev;
 
 use std::mem::ManuallyDrop;
 
@@ -17,6 +18,7 @@ pub use read::Read;
 pub use readv::ReadV;
 pub use openat::OpenAt;
 pub use write::Write;
+pub use writev::WriteV;
 
 /// An IO event that can be scheduled on an io-uring driver.
 ///

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -3,6 +3,7 @@
 mod connect;
 mod close;
 mod read;
+mod readv;
 mod openat;
 mod write;
 
@@ -13,6 +14,7 @@ use crate::cancellation::Cancellation;
 pub use connect::Connect;
 pub use close::Close;
 pub use read::Read;
+pub use readv::ReadV;
 pub use openat::OpenAt;
 pub use write::Write;
 

--- a/src/event/readv.rs
+++ b/src/event/readv.rs
@@ -1,0 +1,45 @@
+use std::io::IoSliceMut; 
+use std::os::unix::io::AsRawFd;
+use std::mem::ManuallyDrop;
+use std::marker::Unpin;
+
+use super::{Event, Cancellation};
+
+/// A `readv` event.
+pub struct ReadV<'a, T> {
+    pub io: &'a T,
+    pub bufs: Vec<Vec<u8>>,
+    pub iovecs: Vec<IoSliceMut<'a>>, 
+    pub offset: usize
+}
+
+impl<'a, T: AsRawFd + Unpin> ReadV<'a, T> {
+    pub fn new(io: &'a T, bufs: Vec<Vec<u8>>, offset: usize) -> ReadV<T> {
+        let mut iovecs = Vec::with_capacity(bufs.len()); 
+        for buf in bufs.iter() { 
+            // Unsafe contract: transmute is defined behaviour because 
+            // IoSliceMut is guaranteed ABI compatible with libc::iovec 
+            // on Unix: https://doc.rust-lang.org/beta/std/io/struct.IoSliceMut.html
+            unsafe { 
+                iovecs.push(std::mem::transmute::<libc::iovec, IoSliceMut>(
+                    libc::iovec { 
+                        iov_base: buf.as_ptr() as *mut libc::c_void, 
+                        iov_len: buf.len() as libc::size_t, 
+                    }
+                )); 
+            }
+        }
+        ReadV { io, iovecs, bufs, offset }
+    }
+}
+
+
+impl<'a, T: AsRawFd + Unpin> Event for ReadV<'a, T> {
+    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+        sqe.prep_read_vectored(self.io.as_raw_fd(), &mut self.iovecs[..], self.offset);
+    }
+
+    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
+        todo!(); 
+    }
+}

--- a/src/event/readv.rs
+++ b/src/event/readv.rs
@@ -17,7 +17,7 @@ impl<'a, T: AsRawFd + Unpin> ReadV<'a, T> {
         ReadV { io, bufs, offset }
     }
 
-    fn iovecs(&mut self) -> &'_ mut [IoSliceMut<'_>] {
+    fn iovecs(&mut self) -> &mut [IoSliceMut] {
         // Unsafe contract:
         // This pointer cast is defined behaviour because Box<[u8]> (wide pointer)
         // is currently ABI compatible with libc::iovec.

--- a/src/event/writev.rs
+++ b/src/event/writev.rs
@@ -1,0 +1,37 @@
+use std::io::IoSlice; 
+use std::os::unix::io::AsRawFd;
+use std::mem::ManuallyDrop;
+use std::marker::Unpin;
+
+use super::{Event, Cancellation};
+
+/// A `writev` event.
+pub struct WriteV<'a, T> {
+    pub io: &'a T,
+    pub bufs: Vec<Box<[u8]>>,
+    pub offset: usize
+}
+
+impl<'a, T: AsRawFd + Unpin> WriteV<'a, T> {
+    pub fn new(io: &'a T, bufs: Vec<Box<[u8]>>, offset: usize) -> WriteV<T> {
+        WriteV { io, bufs, offset }
+    }
+
+    fn iovecs(&self) -> &[IoSlice] {
+        unsafe { & *(&self.bufs[..] as *const [Box<[u8]>] as *const [IoSlice]) }
+    }
+}
+
+impl<'a, T: AsRawFd + Unpin> Event for WriteV<'a, T> {
+    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+        sqe.prep_write_vectored(self.io.as_raw_fd(), self.iovecs(), self.offset);
+    }
+
+    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
+        unsafe fn drop(data: *mut (), cap: usize) {
+            std::mem::drop(Vec::from_raw_parts(data as *mut Box<[u8]>, cap, cap))
+        }
+        let mut bufs: ManuallyDrop<Vec<Box<[u8]>>> = ManuallyDrop::new(ManuallyDrop::take(this).bufs);
+        Cancellation::new(bufs.as_mut_ptr() as *mut (), bufs.capacity(), drop)
+    }
+}

--- a/tests/basic-readv.rs
+++ b/tests/basic-readv.rs
@@ -1,0 +1,22 @@
+use std::fs::File;
+
+use ringbahn::Submission;
+use ringbahn::event::ReadV;
+use ringbahn::drive::demo;
+
+const ASSERT: &[u8] = b"But this formidable power of death -";
+
+#[test]
+fn readv_file() {
+    let file = File::open("props.txt").unwrap();
+    let vec1 = vec![0; 4];
+    let vec2 = vec![0; 5];
+    let vec3 = vec![0; 10];
+    let readv: ReadV<'_, File> = ReadV::new(&file, vec![vec1, vec2, vec3], 0);
+    let (readv, result) = futures::executor::block_on(Submission::new(readv, demo::driver()));
+    dbg!(&result); 
+    assert!(result.is_ok());
+    assert_eq!(readv.bufs[0][..], ASSERT[0..4]); 
+    assert_eq!(readv.bufs[1][..], ASSERT[4..9]); 
+    assert_eq!(readv.bufs[2][..], ASSERT[9..19]); 
+}

--- a/tests/basic-readv.rs
+++ b/tests/basic-readv.rs
@@ -14,7 +14,6 @@ fn readv_file() {
     let vec3 = Box::new([0; 10]);
     let readv: ReadV<'_, File> = ReadV::new(&file, vec![vec1, vec2, vec3], 0);
     let (readv, result) = futures::executor::block_on(Submission::new(readv, demo::driver()));
-    dbg!(&result); 
     assert!(result.is_ok());
     assert_eq!(readv.bufs[0][..], ASSERT[0..4]); 
     assert_eq!(readv.bufs[1][..], ASSERT[4..9]); 

--- a/tests/basic-readv.rs
+++ b/tests/basic-readv.rs
@@ -9,9 +9,9 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 #[test]
 fn readv_file() {
     let file = File::open("props.txt").unwrap();
-    let vec1 = vec![0; 4];
-    let vec2 = vec![0; 5];
-    let vec3 = vec![0; 10];
+    let vec1 = Box::new([0; 4]);
+    let vec2 = Box::new([0; 5]);
+    let vec3 = Box::new([0; 10]);
     let readv: ReadV<'_, File> = ReadV::new(&file, vec![vec1, vec2, vec3], 0);
     let (readv, result) = futures::executor::block_on(Submission::new(readv, demo::driver()));
     dbg!(&result); 

--- a/tests/basic-writev.rs
+++ b/tests/basic-writev.rs
@@ -1,0 +1,23 @@
+use std::fs::File;
+use std::io::Read; 
+
+use ringbahn::Submission;
+use ringbahn::event::WriteV;
+use ringbahn::drive::demo;
+
+const ASSERT: &[u8] = b"But this formidable power of death -";
+
+#[test]
+fn writev_file() {
+    let mut file = tempfile::tempfile().unwrap();
+    let vec1 = &ASSERT[0..4];
+    let vec2 = &ASSERT[4..9];
+    let vec3 = &ASSERT[9..];
+    let writev: WriteV<'_, File> = WriteV::new(&file, vec![vec1.into(), vec2.into(), vec3.into()], 0);
+    let (_, result) = futures::executor::block_on(Submission::new(writev, demo::driver()));
+    assert_eq!(result.unwrap(), ASSERT.len());
+
+    let mut buf = vec![];
+    assert_eq!(file.read_to_end(&mut buf).unwrap(), ASSERT.len());
+    assert_eq!(&buf[0..ASSERT.len()], ASSERT);
+}


### PR DESCRIPTION
I tried to implement a `ReadV` event based on `Read`. 
I mostly wanted to open a PR because of how gross the `iovec` construction is
```rust
unsafe { 
    iovecs.push(std::mem::transmute::<libc::iovec, IoSliceMut>(
        libc::iovec { 
            iov_base: buf.as_ptr() as *mut libc::c_void, 
            iov_len: buf.len() as libc::size_t, 
        }
    )); 
}
```
I am not sure how to properly implement `cancel` for `readv`. 
Given the function pointer 
```rust 
unsafe fn drop(data: *mut (), len: usize)
```
maybe one idea is storing pairs of each `Vec`'s heap pointer and size in the `data` buffer and have the number of buffers in `len` and then you can free them one by one. 