### PR TITLE
Tidy examples

### DIFF
--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -20,7 +20,7 @@ fn main() {
                     println!("read {} bytes", n);
                     buf[n] = b'\n';
                     stream.write_all(&buf[0..n + 1]).await.unwrap();
-                    println!("write {} bytes", n + 1);
+                    println!("wrote {} bytes", n + 1);
                 }
             });
         }

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -11,7 +11,7 @@ fn main() {
     let pool = ThreadPool::new().unwrap();
     block_on(async move {
         while let Some(stream) = incoming.next().await {
-            println!("recieved connection");
+            println!("received connection");
             let (mut stream, _) = stream.unwrap();
             pool.spawn_ok(async move {
                 loop {


### PR DESCRIPTION
- fix a spelling mistake
- ~also use `eprintln!` in place of `println!`~
- switch to paste tense for actions that already occurred